### PR TITLE
feat: 絵文字監視機能の追加

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>net.dv8tion</groupId>
             <artifactId>JDA</artifactId>
-            <version>4.3.0_280</version>
+            <version>4.3.0_283</version>
             <exclusions>
                 <exclusion>
                     <groupId>club.minnced</groupId>

--- a/src/main/java/com/jaoafa/javajaotan2/Main.java
+++ b/src/main/java/com/jaoafa/javajaotan2/Main.java
@@ -56,6 +56,7 @@ public class Main {
     static JavajaotanConfig config;
     static JDA jda;
     static JSONArray commands;
+    static WatchEmojis watchEmojis;
 
     public static void main(String[] args) {
         logger = LoggerFactory.getLogger("Javajaotan2");
@@ -114,6 +115,8 @@ public class Main {
         defineChannelsAndRoles();
 
         registerCommand(jda);
+
+        watchEmojis = new WatchEmojis();
 
         if (!isUserDevelopMode && !isGuildDevelopMode) {
             new HTTPServer().start();
@@ -393,5 +396,9 @@ public class Main {
 
     public static JSONArray getCommands() {
         return commands;
+    }
+
+    public static WatchEmojis getWatchEmojis() {
+        return watchEmojis;
     }
 }

--- a/src/main/java/com/jaoafa/javajaotan2/command/Cmd_WatchEmoji.java
+++ b/src/main/java/com/jaoafa/javajaotan2/command/Cmd_WatchEmoji.java
@@ -1,0 +1,96 @@
+/*
+ * jaoLicense
+ *
+ * Copyright (c) 2021 jao Minecraft Server
+ *
+ * The following license applies to this project: jaoLicense
+ *
+ * Japanese: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE.md
+ * English: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE-en.md
+ */
+
+package com.jaoafa.javajaotan2.command;
+
+import cloud.commandframework.Command;
+import cloud.commandframework.arguments.standard.StringArrayArgument;
+import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.jda.JDACommandSender;
+import cloud.commandframework.jda.parsers.ChannelArgument;
+import cloud.commandframework.meta.CommandMeta;
+import com.jaoafa.javajaotan2.Main;
+import com.jaoafa.javajaotan2.lib.CommandPremise;
+import com.jaoafa.javajaotan2.lib.JavajaotanCommand;
+import com.jaoafa.javajaotan2.lib.WatchEmojis;
+import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageChannel;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class Cmd_WatchEmoji implements CommandPremise {
+    @Override
+    public JavajaotanCommand.Detail details() {
+        return new JavajaotanCommand.Detail(
+            "watchemoji",
+            "絵文字を監視する設定をします。"
+        );
+    }
+
+    @Override
+    public JavajaotanCommand.Cmd register(Command.Builder<JDACommandSender> builder) {
+        return new JavajaotanCommand.Cmd(
+            builder
+                .meta(CommandMeta.DESCRIPTION, "サーバを絵文字監視対象に追加します。")
+                .literal("add")
+                .argument(ChannelArgument
+                    .<JDACommandSender>newBuilder("log_channel")
+                    .withParsers(Arrays
+                        .stream(ChannelArgument.ParserMode.values())
+                        .collect(Collectors.toSet())))
+                .argument(ChannelArgument
+                    .<JDACommandSender>newBuilder("list_channel")
+                    .withParsers(Arrays
+                        .stream(ChannelArgument.ParserMode.values())
+                        .collect(Collectors.toSet())))
+                .handler(context -> execute(context, this::addWatch))
+                .build(),
+            builder
+                .meta(CommandMeta.DESCRIPTION, "サーバを絵文字監視対象から削除します。")
+                .literal("remove", "del", "delete")
+                .handler(context -> execute(context, this::removeWatch))
+                .build()
+        );
+    }
+
+    private void addWatch(@NotNull Guild guild, @NotNull MessageChannel channel, @NotNull Member member, @NotNull Message message, @NotNull CommandContext<JDACommandSender> context) {
+        if (!member.hasPermission(Permission.ADMINISTRATOR)){
+            message.reply("このコマンドを実行するには、サーバの管理者権限を持っている必要があります。").queue();
+        }
+        MessageChannel log_channel = context.get("log_channel");
+        MessageChannel list_channel = context.get("list_channel");
+        WatchEmojis watchEmojis = Main.getWatchEmojis();
+        watchEmojis.addGuild(guild, log_channel, list_channel);
+
+        message.reply(String.format("このサーバ「%s」を絵文字監視対象に追加しました。\nログチャンネル: <#%s>\nリストチャンネル: <#%s>",
+            guild.getName(),
+            log_channel.getId(),
+            list_channel.getId())).queue();
+    }
+
+    private void removeWatch(@NotNull Guild guild, @NotNull MessageChannel channel, @NotNull Member member, @NotNull Message message, @NotNull CommandContext<JDACommandSender> context) {
+        if (!member.hasPermission(Permission.ADMINISTRATOR)){
+            message.reply("このコマンドを実行するには、サーバの管理者権限を持っている必要があります。").queue();
+        }
+        WatchEmojis watchEmojis = Main.getWatchEmojis();
+        watchEmojis.removeGuild(guild);
+
+        message.reply(String.format("このサーバ「%s」を絵文字監視対象から削除しました。", guild.getName())).queue();
+    }
+}

--- a/src/main/java/com/jaoafa/javajaotan2/command/Cmd_WatchEmoji.java
+++ b/src/main/java/com/jaoafa/javajaotan2/command/Cmd_WatchEmoji.java
@@ -12,7 +12,6 @@
 package com.jaoafa.javajaotan2.command;
 
 import cloud.commandframework.Command;
-import cloud.commandframework.arguments.standard.StringArrayArgument;
 import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.jda.JDACommandSender;
 import cloud.commandframework.jda.parsers.ChannelArgument;
@@ -28,10 +27,7 @@ import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageChannel;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 import java.util.stream.Collectors;
 
 public class Cmd_WatchEmoji implements CommandPremise {

--- a/src/main/java/com/jaoafa/javajaotan2/event/Event_WatchEmojis.java
+++ b/src/main/java/com/jaoafa/javajaotan2/event/Event_WatchEmojis.java
@@ -1,0 +1,212 @@
+/*
+ * jaoLicense
+ *
+ * Copyright (c) 2021 jao Minecraft Server
+ *
+ * The following license applies to this project: jaoLicense
+ *
+ * Japanese: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE.md
+ * English: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE-en.md
+ */
+
+package com.jaoafa.javajaotan2.event;
+
+import com.jaoafa.javajaotan2.Main;
+import com.jaoafa.javajaotan2.lib.WatchEmojis;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.audit.ActionType;
+import net.dv8tion.jda.api.audit.AuditLogEntry;
+import net.dv8tion.jda.api.entities.*;
+import net.dv8tion.jda.api.events.emote.EmoteAddedEvent;
+import net.dv8tion.jda.api.events.emote.EmoteRemovedEvent;
+import net.dv8tion.jda.api.events.emote.update.EmoteUpdateNameEvent;
+import net.dv8tion.jda.api.exceptions.ErrorResponseException;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import org.jetbrains.annotations.NotNull;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class Event_WatchEmojis extends ListenerAdapter {
+    @Override
+    public void onEmoteAdded(@NotNull EmoteAddedEvent event) {
+        JDA jda = event.getJDA();
+        Guild guild = event.getGuild();
+        Emote emote = event.getEmote();
+        ListedEmote listedEmote = event.getGuild().retrieveEmoteById(emote.getIdLong()).complete();
+        User user = listedEmote.getUser();
+
+        Optional<WatchEmojis.EmojiGuild> optGuild = Main.getWatchEmojis().getEmojiGuild(guild);
+        if (optGuild.isEmpty()) {
+            return;
+        }
+
+        WatchEmojis.EmojiGuild emojiGuild = optGuild.get();
+        long log_channel_id = emojiGuild.getLogChannelId();
+        TextChannel log_channel = jda.getTextChannelById(log_channel_id);
+        if (log_channel == null) {
+            return;
+        }
+        MessageEmbed embed = new EmbedBuilder()
+            .setAuthor(user.getAsTag(), "https://discord.com/users/" + user.getId(), user.getAvatarUrl())
+            .setTitle(String.format(":new:NEW EMOJI : %s (`:%s:`)", emote.getAsMention(), emote.getName()))
+            .setThumbnail(emote.getImageUrl())
+            .setTimestamp(Instant.now())
+            .build();
+        log_channel.sendMessageEmbeds(embed).queue();
+
+        generateEmojiList(jda, emojiGuild);
+    }
+
+    @Override
+    public void onEmoteUpdateName(@NotNull EmoteUpdateNameEvent event) {
+        JDA jda = event.getJDA();
+        Guild guild = event.getGuild();
+        Emote emote = event.getEmote();
+
+        Optional<WatchEmojis.EmojiGuild> optGuild = Main.getWatchEmojis().getEmojiGuild(guild);
+        if (optGuild.isEmpty()) {
+            return;
+        }
+
+        WatchEmojis.EmojiGuild emojiGuild = optGuild.get();
+        long log_channel_id = emojiGuild.getLogChannelId();
+        TextChannel log_channel = jda.getTextChannelById(log_channel_id);
+        if (log_channel == null) {
+            return;
+        }
+
+        List<AuditLogEntry> entries = guild.retrieveAuditLogs().type(ActionType.EMOTE_UPDATE).limit(5).complete();
+        User user = null;
+        if (!entries.isEmpty()) {
+            for (AuditLogEntry entry : entries) {
+                if (entry.getTargetIdLong() != emote.getIdLong()) {
+                    continue;
+                }
+                user = entry.getUser();
+            }
+        }
+
+        EmbedBuilder embed = new EmbedBuilder()
+            .setTitle(String.format(":repeat:CHANGE EMOJI : %s (`:%s:` -> `:%s:`)", emote.getAsMention(), event.getOldName(), event.getNewName()))
+            .setThumbnail(emote.getImageUrl())
+            .setTimestamp(Instant.now());
+        if(user != null) {
+            embed.setAuthor(user.getAsTag(), "https://discord.com/users/" + user.getId(), user.getAvatarUrl());
+        }
+        log_channel.sendMessageEmbeds(embed.build()).queue();
+
+        generateEmojiList(jda, emojiGuild);
+    }
+
+    @Override
+    public void onEmoteRemoved(@NotNull EmoteRemovedEvent event) {
+        JDA jda = event.getJDA();
+        Guild guild = event.getGuild();
+        Emote emote = event.getEmote();
+
+        Optional<WatchEmojis.EmojiGuild> optGuild = Main.getWatchEmojis().getEmojiGuild(guild);
+        if (optGuild.isEmpty()) {
+            return;
+        }
+
+        WatchEmojis.EmojiGuild emojiGuild = optGuild.get();
+        long log_channel_id = emojiGuild.getLogChannelId();
+        TextChannel log_channel = jda.getTextChannelById(log_channel_id);
+        if (log_channel == null) {
+            return;
+        }
+
+        List<AuditLogEntry> entries = guild.retrieveAuditLogs().type(ActionType.EMOTE_DELETE).limit(5).complete();
+        User user = null;
+        if (!entries.isEmpty()) {
+            for (AuditLogEntry entry : entries) {
+                if (entry.getTargetIdLong() != emote.getIdLong()) {
+                    continue;
+                }
+                user = entry.getUser();
+            }
+        }
+
+        EmbedBuilder embed = new EmbedBuilder()
+            .setTitle(String.format(":wave:DELETED EMOJI : (`:%s:`)", emote.getName()))
+            .setThumbnail(emote.getImageUrl())
+            .setTimestamp(Instant.now());
+        if(user != null) {
+            embed.setAuthor(user.getAsTag(), "https://discord.com/users/" + user.getId(), user.getAvatarUrl());
+        }
+        log_channel.sendMessageEmbeds(embed.build()).queue();
+
+        generateEmojiList(jda, emojiGuild);
+    }
+
+    private void generateEmojiList(JDA jda, WatchEmojis.EmojiGuild emojiGuild) {
+        long list_channel_id = emojiGuild.getListChannelId();
+        List<Long> list_message_ids = emojiGuild.getListMessageIds();
+        TextChannel channel = jda.getTextChannelById(list_channel_id);
+        Guild guild = jda.getGuildById(emojiGuild.getGuildId());
+        if (guild == null || channel == null) {
+            return;
+        }
+        List<String> emoji_list = getEmojiList(guild);
+        List<String> split_emojis = split1900chars(emoji_list);
+
+        List<Message> list_messages = list_message_ids.stream().map(s -> getMessage(channel, s)).collect(Collectors.toList());
+        if (list_messages.stream().anyMatch(Objects::isNull)) {
+            list_messages.forEach(m -> m.delete().queue()); // 一つでもメッセージが存在しなかったら、すべてのメッセージを削除する
+            list_messages.clear();
+            emojiGuild.clearListMessageIds();
+        }
+
+        for (int i = 0; i < split_emojis.size(); i++) {
+            String emoji_list_str = split_emojis.get(i);
+            if (i >= list_messages.size()) {
+                // メッセージ作成
+                channel.sendMessage(emoji_list_str).queue(emojiGuild::addListMessage, Throwable::printStackTrace);
+            } else {
+                // 既存メッセージ利用
+                Message message = list_messages.get(i);
+                message.editMessage(emoji_list_str).queue();
+            }
+        }
+    }
+
+    private Message getMessage(TextChannel channel, long message_id) {
+        try {
+            return channel.retrieveMessageById(message_id).complete();
+        } catch (ErrorResponseException e) {
+            return null;
+        }
+    }
+
+    private List<String> getEmojiList(Guild guild) {
+        return guild
+            .getEmotes()
+            .stream()
+            .map(e -> String.format("%s = `:%s:`", e.getAsMention(), e.getName()))
+            .collect(Collectors.toList());
+    }
+
+    private List<String> split1900chars(List<String> strList) {
+        List<String> split = new ArrayList<>();
+        StringBuilder builder = new StringBuilder();
+        for (String str : strList) {
+            if (builder.length() + str.length() > 1900) {
+                // この項目を入れると1900文字を超えてしまう
+                split.add(builder.toString().trim());
+                builder = new StringBuilder();
+            }
+            builder.append(str);
+            builder.append("\n");
+        }
+        if(builder.length() != 0){
+            split.add(builder.toString().trim());
+        }
+        return split;
+    }
+}

--- a/src/main/java/com/jaoafa/javajaotan2/lib/CmdFunction.java
+++ b/src/main/java/com/jaoafa/javajaotan2/lib/CmdFunction.java
@@ -23,9 +23,4 @@ import org.jetbrains.annotations.NotNull;
 public interface CmdFunction {
     void execute(@NotNull Guild guild, @NotNull MessageChannel channel, @NotNull Member member, @NotNull Message message, @NotNull CommandContext<JDACommandSender> context);
 
-    class NullCommandExecutionHandler implements CmdFunction {
-        @Override
-        public void execute(@NotNull Guild guild, @NotNull MessageChannel channel, @NotNull Member member, @NotNull Message message, @NotNull CommandContext<JDACommandSender> context) {
-        }
-    }
 }

--- a/src/main/java/com/jaoafa/javajaotan2/lib/CommandPremise.java
+++ b/src/main/java/com/jaoafa/javajaotan2/lib/CommandPremise.java
@@ -41,7 +41,7 @@ public interface CommandPremise {
      */
     default void execute(CommandContext<JDACommandSender> context, CmdFunction handler) {
         MessageChannel channel = context.getSender().getChannel();
-        if (!context.getSender().getEvent().isPresent()) {
+        if (context.getSender().getEvent().isEmpty()) {
             channel.sendMessage("メッセージデータを取得できなかったため、処理に失敗しました。").queue();
             return;
         }

--- a/src/main/java/com/jaoafa/javajaotan2/lib/JavajaotanConfig.java
+++ b/src/main/java/com/jaoafa/javajaotan2/lib/JavajaotanConfig.java
@@ -21,7 +21,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 
 public class JavajaotanConfig {
-    Logger logger;
+    final Logger logger;
     String token;
     long guild_id;
 

--- a/src/main/java/com/jaoafa/javajaotan2/lib/WatchEmojis.java
+++ b/src/main/java/com/jaoafa/javajaotan2/lib/WatchEmojis.java
@@ -1,0 +1,126 @@
+/*
+ * jaoLicense
+ *
+ * Copyright (c) 2021 jao Minecraft Server
+ *
+ * The following license applies to this project: jaoLicense
+ *
+ * Japanese: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE.md
+ * English: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE-en.md
+ */
+
+package com.jaoafa.javajaotan2.lib;
+
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageChannel;
+import org.jetbrains.annotations.NotNull;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class WatchEmojis {
+    File file;
+    List<EmojiGuild> guilds = new ArrayList<>();
+
+    public WatchEmojis() {
+        file = new File("watch-emojis.json");
+        load();
+    }
+
+    public void addGuild(@NotNull Guild guild, @NotNull MessageChannel log_channel, @NotNull MessageChannel list_channel) {
+        guilds.add(new EmojiGuild(guild.getIdLong(), log_channel.getIdLong(), list_channel.getIdLong(), new ArrayList<>()));
+        save();
+    }
+
+    public void removeGuild(@NotNull Guild guild) {
+        guilds = guilds.stream().filter(g -> g.guild_id != guild.getIdLong()).collect(Collectors.toList());
+        save();
+    }
+
+    public Optional<EmojiGuild> getEmojiGuild(@NotNull Guild guild) {
+        return guilds.stream().filter(g -> g.guild_id == guild.getIdLong()).findFirst();
+    }
+
+    public void load() {
+        if (!file.exists()) {
+            return;
+        }
+        try {
+            guilds.clear();
+            String json = Files.readString(file.toPath());
+            JSONArray array = new JSONArray(json);
+            for (int i = 0; i < array.length(); i++) {
+                JSONObject obj = array.getJSONObject(i);
+                List<Long> list_message_ids = obj.has("list_message_ids") ?
+                    obj.getJSONArray("list_message_ids").toList().stream().map(o -> (long) o).collect(Collectors.toList()) :
+                    new ArrayList<>();
+                guilds.add(new EmojiGuild(obj.getLong("guild_id"), obj.getLong("log_channel_id"), obj.getLong("list_channel_id"), list_message_ids));
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void save() {
+        JSONArray array = new JSONArray();
+        guilds.stream().map(EmojiGuild::asJSONObject).forEach(array::put);
+        try {
+            Files.writeString(file.toPath(), array.toString());
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static class EmojiGuild {
+        long guild_id;
+        long log_channel_id;
+        long list_channel_id;
+        List<Long> list_message_ids;
+
+        public EmojiGuild(long guild_id, long log_channel_id, long list_channel_id, List<Long> list_message_ids) {
+            this.guild_id = guild_id;
+            this.log_channel_id = log_channel_id;
+            this.list_channel_id = list_channel_id;
+            this.list_message_ids = list_message_ids;
+        }
+
+        public long getGuildId() {
+            return guild_id;
+        }
+
+        public long getLogChannelId() {
+            return log_channel_id;
+        }
+
+        public long getListChannelId() {
+            return list_channel_id;
+        }
+
+        public List<Long> getListMessageIds() {
+            return list_message_ids;
+        }
+
+        public void clearListMessageIds(){
+            list_message_ids.clear();
+        }
+
+        public void addListMessage(Message message){
+            list_message_ids.add(message.getIdLong());
+        }
+
+        public JSONObject asJSONObject() {
+            return new JSONObject()
+                .put("guild_id", guild_id)
+                .put("log_channel_id", log_channel_id)
+                .put("list_channel_id", list_channel_id);
+        }
+    }
+}

--- a/src/main/java/com/jaoafa/javajaotan2/lib/WatchEmojis.java
+++ b/src/main/java/com/jaoafa/javajaotan2/lib/WatchEmojis.java
@@ -27,7 +27,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class WatchEmojis {
-    File file;
+    final File file;
     List<EmojiGuild> guilds = new ArrayList<>();
 
     public WatchEmojis() {
@@ -80,10 +80,10 @@ public class WatchEmojis {
     }
 
     public static class EmojiGuild {
-        long guild_id;
-        long log_channel_id;
-        long list_channel_id;
-        List<Long> list_message_ids;
+        final long guild_id;
+        final long log_channel_id;
+        final long list_channel_id;
+        final List<Long> list_message_ids;
 
         public EmojiGuild(long guild_id, long log_channel_id, long list_channel_id, List<Long> list_message_ids) {
             this.guild_id = guild_id;


### PR DESCRIPTION
絵文字監視機能

- `/watchemoji add <ログチャンネル> <絵文字リストチャンネル>`: 絵文字が追加・変更・削除されたときに通知し絵文字リストを生成するよう設定します。(絵文字監視)
- `/watchemoji remove`: 絵文字監視を解除します。
- 自動的にログチャンネルへ絵文字の追加・変更・削除を通知します。また絵文字の追加・変更・削除を行ったユーザーも表示します。
- 自動的に絵文字リストチャンネルで絵文字のリストを生成します。既存のメッセージがある場合はそのメッセージを編集します。