### PR TITLE
feat: Discordメンバーの自動整理

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 11
+      - name: Set up JDK 16
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 16
       - name: Cache local Maven repository
         uses: actions/cache@v2
         with:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,6 +21,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
+      - name: Set up JDK 16
+        uses: actions/setup-java@v1
+        with:
+          java-version: 16
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v1
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -26,8 +26,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
+                    <source>16</source>
+                    <target>16</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -132,6 +132,11 @@
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
             <version>1.15</version>
+        </dependency>
+        <dependency>
+            <groupId>org.quartz-scheduler</groupId>
+            <artifactId>quartz</artifactId>
+            <version>2.3.2</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/com/jaoafa/javajaotan2/Main.java
+++ b/src/main/java/com/jaoafa/javajaotan2/Main.java
@@ -22,6 +22,7 @@ import cloud.commandframework.jda.JDACommandSender;
 import cloud.commandframework.jda.JDAGuildSender;
 import cloud.commandframework.meta.CommandMeta;
 import com.jaoafa.javajaotan2.lib.*;
+import com.jaoafa.javajaotan2.tasks.Task_PermSync;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.JDABuilder;
 import net.dv8tion.jda.api.entities.Guild;
@@ -31,6 +32,8 @@ import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import net.dv8tion.jda.api.requests.GatewayIntent;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.quartz.*;
+import org.quartz.impl.StdSchedulerFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,6 +48,7 @@ import java.text.MessageFormat;
 import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.Iterator;
+import java.util.List;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
@@ -117,6 +121,7 @@ public class Main {
         copyExternalScripts();
 
         registerCommand(jda);
+        registerTask();
 
         watchEmojis = new WatchEmojis();
 
@@ -162,8 +167,7 @@ public class Main {
                 sender -> {
                     MessageReceivedEvent event = sender.getEvent().orElse(null);
 
-                    if (sender instanceof JDAGuildSender) {
-                        JDAGuildSender jdaGuildSender = (JDAGuildSender) sender;
+                    if (sender instanceof JDAGuildSender jdaGuildSender) {
                         return new JDAGuildSender(event, jdaGuildSender.getMember(), jdaGuildSender.getTextChannel());
                     }
 
@@ -172,8 +176,7 @@ public class Main {
                 user -> {
                     MessageReceivedEvent event = user.getEvent().orElse(null);
 
-                    if (user instanceof JDAGuildSender) {
-                        JDAGuildSender guildUser = (JDAGuildSender) user;
+                    if (user instanceof JDAGuildSender guildUser) {
                         return new JDAGuildSender(event, guildUser.getMember(), guildUser.getTextChannel());
                     }
 
@@ -189,7 +192,7 @@ public class Main {
                 (c, e) -> {
                     logger.info("InvalidSyntaxException: " + e.getMessage() + " (From " + c.getUser().getAsTag() + " in " + c.getChannel().getName() + ")");
                     if (c.getEvent().isPresent()) {
-                        if(isGuildDevelopMode && developGuildId != c.getEvent().get().getGuild().getIdLong()){
+                        if (isGuildDevelopMode && developGuildId != c.getEvent().get().getGuild().getIdLong()) {
                             return;
                         }
                         c.getEvent().get().getMessage().reply(String.format("コマンドの構文が不正です。正しい構文: `%s`", e.getCorrectSyntax())).queue();
@@ -202,7 +205,7 @@ public class Main {
                     return;
                 }
                 if (c.getEvent().isPresent()) {
-                    if(isGuildDevelopMode && developGuildId != c.getEvent().get().getGuild().getIdLong()){
+                    if (isGuildDevelopMode && developGuildId != c.getEvent().get().getGuild().getIdLong()) {
                         return;
                     }
                     c.getEvent().get().getMessage().reply("コマンドを使用する権限がありません。").queue();
@@ -213,7 +216,7 @@ public class Main {
                 logger.info("CommandExecutionException: " + e.getMessage() + " (From " + c.getUser().getAsTag() + " in " + c.getChannel().getName() + ")");
                 e.printStackTrace();
                 if (c.getEvent().isPresent()) {
-                    if(isGuildDevelopMode && developGuildId != c.getEvent().get().getGuild().getIdLong()){
+                    if (isGuildDevelopMode && developGuildId != c.getEvent().get().getGuild().getIdLong()) {
                         return;
                     }
                     c.getEvent().get().getMessage().reply(MessageFormat.format("コマンドの実行に失敗しました: {0} ({1})",
@@ -243,10 +246,10 @@ public class Main {
                     CommandPremise cmdPremise = (CommandPremise) instance;
 
                     Command.Builder<JDACommandSender> builder = manager.commandBuilder(
-                        commandName,
-                        ArgumentDescription.of(cmdPremise.details().getDescription()),
-                        cmdPremise.details().getAliases().toArray(new String[0])
-                    )
+                            commandName,
+                            ArgumentDescription.of(cmdPremise.details().getDescription()),
+                            cmdPremise.details().getAliases().toArray(new String[0])
+                        )
                         .meta(CommandMeta.DESCRIPTION, cmdPremise.details().getDescription());
                     if (cmdPremise.details().getAllowRoles() != null) {
                         builder = builder.permission(
@@ -342,6 +345,42 @@ public class Main {
             getLogger().error("イベントの登録に失敗しました。");
             e.printStackTrace();
         }
+    }
+
+    static void registerTask() {
+        SchedulerFactory factory = new StdSchedulerFactory();
+        List<TaskConfig> tasks = List.of(
+            new TaskConfig(
+                Task_PermSync.class,
+                "permsync",
+                "javajaotan2",
+                TimeOfDay.hourMinuteAndSecondOfDay(0, 0, 0))
+        );
+
+        try {
+            Scheduler scheduler = factory.getScheduler();
+            scheduler.start();
+
+            for (TaskConfig task : tasks) {
+                logger.info("registerTask: " + task.name() + " -> " + task.timeOfDay().toString());
+                scheduler.scheduleJob(
+                    JobBuilder.newJob(Task_PermSync.class)
+                        .withIdentity(task.name(), task.group())
+                        .build(),
+                    TriggerBuilder.newTrigger()
+                        .withIdentity(task.name(), task.group())
+                        .withSchedule(DailyTimeIntervalScheduleBuilder
+                            .dailyTimeIntervalSchedule()
+                            .startingDailyAt(task.timeOfDay()))
+                        .build()
+                );
+            }
+        } catch (SchedulerException e) {
+            e.printStackTrace();
+        }
+    }
+
+    record TaskConfig(Class<? extends Job> clazz, String name, String group, TimeOfDay timeOfDay) {
     }
 
     static void defineChannelsAndRoles() {

--- a/src/main/java/com/jaoafa/javajaotan2/command/Cmd_Test.java
+++ b/src/main/java/com/jaoafa/javajaotan2/command/Cmd_Test.java
@@ -18,11 +18,13 @@ import cloud.commandframework.meta.CommandMeta;
 import com.jaoafa.javajaotan2.lib.CommandPremise;
 import com.jaoafa.javajaotan2.lib.JavajaotanCommand;
 import com.jaoafa.javajaotan2.lib.Roles;
+import com.jaoafa.javajaotan2.tasks.Task_PermSync;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageChannel;
 import org.jetbrains.annotations.NotNull;
+import org.quartz.JobExecutionException;
 
 import java.text.MessageFormat;
 import java.util.Arrays;
@@ -45,11 +47,24 @@ public class Cmd_Test implements CommandPremise {
                 .meta(CommandMeta.DESCRIPTION, "あなたのユーザーIDを表示します。")
                 .literal("userid")
                 .handler(context -> execute(context, this::getUserId))
+                .build(),
+            builder
+                .meta(CommandMeta.DESCRIPTION, "PermSyncの動作テストを行います")
+                .literal("permsync")
+                .handler(context -> execute(context, this::runPermSync))
                 .build()
         );
     }
 
     private void getUserId(@NotNull Guild guild, @NotNull MessageChannel channel, @NotNull Member member, @NotNull Message message, @NotNull CommandContext<JDACommandSender> context) {
         message.reply(MessageFormat.format("あなたのユーザーIDは `{0}` です。", member.getId())).queue();
+    }
+
+    private void runPermSync(@NotNull Guild guild, @NotNull MessageChannel channel, @NotNull Member member, @NotNull Message message, @NotNull CommandContext<JDACommandSender> context) {
+        try {
+            new Task_PermSync(true).execute(null);
+        } catch (JobExecutionException e) {
+            e.printStackTrace();
+        }
     }
 }

--- a/src/main/java/com/jaoafa/javajaotan2/lib/SubAccount.java
+++ b/src/main/java/com/jaoafa/javajaotan2/lib/SubAccount.java
@@ -1,0 +1,163 @@
+/*
+ * jaoLicense
+ *
+ * Copyright (c) 2021 jao Minecraft Server
+ *
+ * The following license applies to this project: jaoLicense
+ *
+ * Japanese: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE.md
+ * English: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE-en.md
+ */
+
+package com.jaoafa.javajaotan2.lib;
+
+import com.jaoafa.javajaotan2.Main;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Role;
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.exceptions.ErrorResponseException;
+import org.jetbrains.annotations.NotNull;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashSet;
+import java.util.Set;
+
+public class SubAccount {
+    private Guild jMSGuild = null;
+    private boolean exists = true;
+    private User user = null;
+    private long discordId;
+
+    public SubAccount(long discordId) {
+        try {
+            this.discordId = discordId;
+            this.jMSGuild = Main.getJDA().getGuildById(597378876556967936L);
+
+            JavajaotanData.getMainMySQLDBManager().getConnection();
+
+            try {
+                this.user = Main.getJDA().retrieveUserById(discordId).complete();
+            } catch (ErrorResponseException e) {
+                exists = false;
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+            exists = false;
+        }
+    }
+
+    public SubAccount(Member member) {
+        try {
+            this.discordId = member.getIdLong();
+            this.jMSGuild = Main.getJDA().getGuildById(597378876556967936L);
+
+            JavajaotanData.getMainMySQLDBManager().getConnection();
+
+            this.user = member.getUser();
+        } catch (SQLException e) {
+            e.printStackTrace();
+            exists = false;
+        }
+    }
+
+    public boolean setMainAccount(@NotNull SubAccount mainAccount) {
+        Role SubAccountRole = jMSGuild.getRoleById(753047225751568474L);
+        if (SubAccountRole == null) {
+            return false;
+        }
+        try {
+            MySQLDBManager manager = JavajaotanData.getMainMySQLDBManager();
+            Connection conn = manager.getConnection();
+
+            PreparedStatement stmt = conn.prepareStatement("INSERT INTO subaccount (name, discriminator, disid, main_name, main_discriminator, main_disid, created_at) VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP);");
+            stmt.setString(1, user.getName());
+            stmt.setString(2, user.getDiscriminator());
+            stmt.setLong(3, user.getIdLong());
+            stmt.setString(4, mainAccount.getUser().getName());
+            stmt.setString(5, mainAccount.getUser().getDiscriminator());
+            stmt.setLong(6, mainAccount.getUser().getIdLong());
+            stmt.executeUpdate();
+        } catch (SQLException e) {
+            return false;
+        }
+        jMSGuild.addRoleToMember(user.getId(), SubAccountRole).queue();
+        return true;
+    }
+
+    public boolean removeMainAccount() {
+        Role SubAccountRole = jMSGuild.getRoleById(753047225751568474L);
+        if (SubAccountRole == null) {
+            return false;
+        }
+        try {
+            MySQLDBManager manager = JavajaotanData.getMainMySQLDBManager();
+            Connection conn = manager.getConnection();
+
+            PreparedStatement stmt = conn.prepareStatement("DELETE FROM subaccount WHERE disid = ?");
+            stmt.setLong(1, user.getIdLong());
+            stmt.executeUpdate();
+        } catch (SQLException e) {
+            return false;
+        }
+        jMSGuild.removeRoleFromMember(user.getId(), SubAccountRole).queue();
+        return true;
+    }
+
+    public boolean isExists() {
+        return exists;
+    }
+
+    public boolean isSubAccount() {
+        return getMainAccount() != null;
+    }
+
+    public long getDiscordId() {
+        return discordId;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public SubAccount getMainAccount() {
+        try {
+            MySQLDBManager manager = JavajaotanData.getMainMySQLDBManager();
+            Connection conn = manager.getConnection();
+            PreparedStatement stmt = conn.prepareStatement("SELECT * FROM subaccount WHERE disid = ?");
+            stmt.setLong(1, discordId);
+            ResultSet res = stmt.executeQuery();
+            SubAccount main = null;
+            if (res.next()) {
+                main = new SubAccount(res.getLong("main_disid"));
+            }
+            res.close();
+            stmt.close();
+            return main;
+        } catch (SQLException e) {
+            return null;
+        }
+    }
+
+    public Set<SubAccount> getSubAccounts() {
+        try {
+            MySQLDBManager manager = JavajaotanData.getMainMySQLDBManager();
+            Connection conn = manager.getConnection();
+            PreparedStatement stmt_sub = conn.prepareStatement("SELECT * FROM subaccount WHERE main_disid = ?");
+            stmt_sub.setLong(1, discordId);
+            ResultSet res_sub = stmt_sub.executeQuery();
+            final Set<SubAccount> subAccounts = new HashSet<>();
+            while (res_sub.next()) {
+                subAccounts.add(new SubAccount(res_sub.getLong("disid")));
+            }
+            res_sub.close();
+            stmt_sub.close();
+            return subAccounts;
+        } catch (SQLException e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/jaoafa/javajaotan2/tasks/Task_PermSync.java
+++ b/src/main/java/com/jaoafa/javajaotan2/tasks/Task_PermSync.java
@@ -1,0 +1,512 @@
+/*
+ * jaoLicense
+ *
+ * Copyright (c) 2021 jao Minecraft Server
+ *
+ * The following license applies to this project: jaoLicense
+ *
+ * Japanese: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE.md
+ * English: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE-en.md
+ */
+
+package com.jaoafa.javajaotan2.tasks;
+
+import com.jaoafa.javajaotan2.Main;
+import com.jaoafa.javajaotan2.lib.JavajaotanData;
+import com.jaoafa.javajaotan2.lib.MySQLDBManager;
+import com.jaoafa.javajaotan2.lib.SubAccount;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.*;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.slf4j.Logger;
+
+import java.awt.*;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.*;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * Minecraft-Discord Connect(/link) に基づき、以下の利用者整理処理を行う
+ * ここでの1ヶ月は30日とする。
+ * (dryRun引数がTrueの場合は対象のメンバーのみを抽出)
+ * <p>
+ * - 参加してから10分以内に発言のないユーザーをキックする
+ * - 参加してから1週間以内にlink・サブアカウント登録・サポートへの問い合わせがない場合はキックする
+ * - 参加してから3週間後にサポート問い合わせのみの場合はキックする
+ * - linkされているのに、Guildにいない利用者のlinkを解除する
+ * - Minecraft-Discord Connectがなされていて、MinecraftConnected役職か付与されていない利用者に対して、MinecraftConnected役職を付与する
+ * - Minecraft-Discord Connectがなされておらず、MinecraftConnected役職か付与されている利用者に対して、MinecraftConnected役職を剥奪する
+ * - MinecraftConnected役職がついている場合、Verified, Regularの役職に応じて役職を付与する
+ * - MinecraftConnected役職がついていない場合、Verified, Community Regular, Regular役職を剥奪する
+ * - 最終ログインから2ヶ月が経過している場合、警告リプライを#generalで送信する
+ * - 最終ログインから3ヶ月が経過している場合、linkをdisabledにし、MinecraftConnected権限を剥奪する
+ * - メインアカウントが1か月以上前に退出しているのにも関わらず、SubAccount役職がついている利用者から本役職を外す。
+ * <p>
+ * - 解除関連処理時、ExpiredDateが設定されている場合は、期限日は最終ログインから3ヶ月後かExpiredDateのいずれか遅い方を使用する
+ * <p>
+ */
+public class Task_PermSync implements Job {
+    boolean dryRun;
+    Logger logger;
+    Connection conn;
+    Role RegularRole;
+    Role CommunityRegularRole;
+    Role VerifiedRole;
+    Role MinecraftConnectedRole;
+    Role MailVerifiedRole;
+    Role NeedSupportRole;
+    Role SubAccountRole;
+    TextChannel generalChannel;
+
+    public Task_PermSync() {
+        this.dryRun = false;
+    }
+
+    public Task_PermSync(boolean dryRun) {
+        this.dryRun = dryRun;
+    }
+
+    @Override
+    public void execute(JobExecutionContext jobExecutionContext) throws JobExecutionException {
+        Guild guild = Main.getJDA().getGuildById(Main.getConfig().getGuildId());
+        if (guild == null) {
+            return;
+        }
+
+        logger = Main.getLogger();
+        MySQLDBManager manager = JavajaotanData.getMainMySQLDBManager();
+        try {
+            conn = manager.getConnection();
+        } catch (SQLException e) {
+            e.printStackTrace();
+            return;
+        }
+
+        List<MinecraftDiscordConnection> connections = getConnections();
+        if (connections == null) {
+            return;
+        }
+
+        RegularRole = guild.getRoleById(597405176189419554L);
+        CommunityRegularRole = guild.getRoleById(888150763421970492L);
+        VerifiedRole = guild.getRoleById(597405176969560064L);
+        MinecraftConnectedRole = guild.getRoleById(604011598952136853L);
+        MailVerifiedRole = guild.getRoleById(597421078817669121L);
+        NeedSupportRole = guild.getRoleById(786110419470254102L);
+        SubAccountRole = guild.getRoleById(753047225751568474L);
+
+        generalChannel = guild.getTextChannelById(597419057251090443L);
+        if (generalChannel == null) {
+            return;
+        }
+
+        guild
+            .loadMembers()
+            .onSuccess(members -> members
+                .forEach(member -> runMember(connections, member.hasTimeJoined() ? member : guild.retrieveMember(member.getUser()).complete())));
+    }
+
+    private void runMember(List<MinecraftDiscordConnection> connections, Member member) {
+        Guild guild = member.getGuild();
+        logger.info("[%s] Role: %s".formatted(
+            member.getUser().getAsTag(),
+            member.getRoles().stream().map(Role::getName).collect(Collectors.joining(", "))
+        ));
+        Notified notified = new Notified(member);
+        MinecraftDiscordConnection mdc = connections
+            .stream()
+            .filter(c -> c.disid().equals(member.getId()))
+            .findFirst()
+            .orElse(null);
+        boolean isRegular = isGrantedRole(member, RegularRole, "Regular");
+        boolean isCommunityRegular = isGrantedRole(member, CommunityRegularRole, "CommunityRegular");
+        boolean isVerified = isGrantedRole(member, VerifiedRole, "Verified");
+        boolean isMinecraftConnected = isGrantedRole(member, MinecraftConnectedRole, "MinecraftConnected");
+        boolean isMailVerified = isGrantedRole(member, MailVerifiedRole, "MailVerified");
+        boolean isNeedSupport = isGrantedRole(member, NeedSupportRole, "NeedSupport");
+        boolean isSubAccount = isGrantedRole(member, SubAccountRole, "SubAccount");
+
+        String minecraftId;
+        UUID uuid = null;
+        if (mdc != null) {
+            minecraftId = mdc.player();
+            uuid = mdc.uuid();
+            logger.info("[%s] Minecraft link: %s (%s)".formatted(
+                member.getUser().getAsTag(),
+                minecraftId,
+                uuid)
+            );
+        } else {
+            logger.info("[%s] Minecraft link: NOT LINKED".formatted(
+                member.getUser().getAsTag()));
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime joinedTime = member.getTimeJoined().atZoneSameInstant(ZoneId.of("Asia/Tokyo")).toLocalDateTime();
+        LocalDateTime loginDate = mdc != null ? mdc.loginDate().toLocalDateTime() : null;
+        long joinMinutes = ChronoUnit.MINUTES.between(joinedTime, now);
+        long joinDays = ChronoUnit.DAYS.between(joinedTime, now);
+        logger.info("joinMinutes(Days): %s days (%s minutes)".formatted(joinDays, joinMinutes));
+
+        if (!isMailVerified && !isNeedSupport && joinMinutes >= 10) {
+            // 参加してから10分以内に発言のないユーザーをキックする
+            kickDiscord(member, "MailVerifiedキック", "10分以上発言がなかったため、キックしました。", Color.PINK);
+            return;
+        }
+
+        if (!isMinecraftConnected && !isSubAccount && !isNeedSupport && joinDays >= 7) {
+            // 参加してから1週間以内にlink・サブアカウント登録・サポートへの問い合わせがない場合はキックする
+            kickDiscord(member, "1weekキック", "1週間(7日)以上link・サブアカウント登録・サポートへの問い合わせがなかったため、キックしました。", Color.PINK);
+            return;
+        }
+
+        if (!isMinecraftConnected && !isSubAccount && isNeedSupport && joinDays >= 21) {
+            // 参加してから3週間後にサポート問い合わせのみの場合はキックする
+            kickDiscord(member, "3weeksキック (NeedSupport)", "3週間(21日)以上link・サブアカウント登録がなかったため、キックしました。", Color.PINK);
+            return;
+        }
+
+        SubAccount subAccount = new SubAccount(member);
+        if (isSubAccount && !subAccount.isSubAccount()) {
+            // SubAccount役職なのにサブアカウントではない
+            notifyConnection(member, "SubAccount役職剥奪", "SubAccount役職が付与されていましたが、サブアカウント登録がなされていないため剥奪しました。", Color.RED);
+            if (!dryRun) guild.addRoleToMember(member, SubAccountRole).queue();
+            isSubAccount = false;
+        }
+
+        if (isSubAccount) {
+            // メインアカウントが1か月以上前に退出しているのにも関わらず、SubAccount役職がついている利用者から本役職を外す。
+            // 多分この実装は不十分
+            MinecraftDiscordConnection subMdc = connections
+                .stream()
+                .filter(c -> c.disid().equals(subAccount.getMainAccount().getUser().getId()))
+                .findFirst()
+                .orElse(null);
+            if (subMdc == null) {
+                notifyConnection(member, "SubAccount役職剥奪", "メインアカウントの情報が取得できなかったため、剥奪しました。", Color.YELLOW);
+                if (!dryRun) {
+                    subAccount.removeMainAccount();
+                    guild.addRoleToMember(member, SubAccountRole).queue();
+                }
+                isSubAccount = false;
+            } else if (subMdc.disabled()) {
+                long deadDays = ChronoUnit.DAYS.between(subMdc.dead_at().toLocalDateTime(), now);
+                if (deadDays >= 30) {
+                    // disabled & 30日経過
+                    notifyConnection(member, "SubAccount役職剥奪", "メインアカウントが1か月(30日)以上前にlinkを切断しているため、剥奪しました。", Color.YELLOW);
+                    if (!dryRun) {
+                        subAccount.removeMainAccount();
+                        guild.addRoleToMember(member, SubAccountRole).queue();
+                    }
+                    isSubAccount = false;
+                }
+            }
+        }
+
+        if (isSubAccount && !isMinecraftConnected) {
+            return; // サブアカウントの場合、10分チェックとかのみ (Minecraft linkされている場合は除外)
+        }
+
+        if (mdc != null && !mdc.disabled() && !isMinecraftConnected) {
+            // Minecraft-Discord Connectがなされていて、MinecraftConnected役職か付与されていない利用者に対して、MinecraftConnected役職を付与する
+            notifyConnection(member, "MinecraftConnected役職付与", "linkがされていたため、MinecraftConnected役職を付与しました。", Color.BLUE);
+            if (!dryRun) guild.addRoleToMember(member, MinecraftConnectedRole).queue();
+            isMinecraftConnected = true;
+        }
+        if ((mdc == null || mdc.disabled()) && isMinecraftConnected) {
+            // Minecraft-Discord Connectがなされておらず、MinecraftConnected役職か付与されている利用者に対して、MinecraftConnected役職を剥奪する
+            notifyConnection(member, "MinecraftConnected役職剥奪", "linkがされていなかったため、MinecraftConnected役職を剥奪しました。", Color.BLUE);
+            if (!dryRun) member.getGuild().addRoleToMember(member, MinecraftConnectedRole).queue();
+            isMinecraftConnected = false;
+        }
+
+        if (isMinecraftConnected) {
+            // MinecraftConnected役職がついている場合、Verified, Regularの役職に応じて役職を付与する
+
+            PermissionGroup group = getPermissionGroup(uuid);
+            if (group == null) {
+                logger.info("[%s] Minecraft Group: グループの取得に失敗".formatted(
+                    member.getUser().getAsTag()));
+                return;
+            }
+            logger.info("[%s] Minecraft Group: %s".formatted(
+                member.getUser().getAsTag(), group.name()));
+
+            if (!isVerified && group == PermissionGroup.VERIFIED) {
+                notifyConnection(member, "Verified役職付与", "Minecraft鯖内の権限に基づき、Verified役職を付与しました。", Color.CYAN);
+                if (!dryRun) guild.addRoleToMember(member, VerifiedRole).queue();
+            }
+            if (!isRegular && group == PermissionGroup.REGULAR) {
+                notifyConnection(member, "Regular役職付与", "Minecraft鯖内の権限に基づき、Regular役職を付与しました。", Color.CYAN);
+                if (!dryRun) guild.addRoleToMember(member, RegularRole).queue();
+            }
+
+            Timestamp checkTS = getMaxTimestamp(mdc.loginDate(), mdc.expired_date());
+            long checkDays = loginDate != null ? ChronoUnit.DAYS.between(checkTS.toLocalDateTime(), now) : -1;
+            logger.info("checkDays: %s".formatted(checkDays));
+            // 最終ログインから2ヶ月(60日)が経過している場合、警告リプライを#generalで送信する
+            if (checkDays >= 60 && !notified.isNotified(Notified.NotifiedType.MONTH2)) {
+                notifyConnection(member, "2か月経過", "最終ログインから2か月が経過したため、#generalで通知します。", Color.MAGENTA);
+                if (!dryRun) {
+                    generalChannel.sendMessage("""
+                        <#%s> あなたのDiscordアカウントに接続されているMinecraftアカウント「`%s`」が**最終ログインから2ヶ月経過**致しました。
+                        **サーバルール及び個別規約により、3ヶ月を経過すると建築物や自治体の所有権がなくなり、運営によって撤去・移動ができる**ようになり、またMinecraftアカウントとの連携が自動的に解除されます。
+                        本日から1ヶ月以内にjao Minecraft Serverにログインがなされない場合、上記のような対応がなされる場合がございますのでご注意ください。""").queue();
+                    notified.setNotified(Notified.NotifiedType.MONTH2);
+                }
+            }
+
+            // 最終ログインから3ヶ月が経過している場合、linkをdisabledにし、MinecraftConnected権限を剥奪する
+            if (checkDays >= 90) {
+                notifyConnection(member, "3monthリンク切断", "最終ログインから3か月が経過したため、linkを切断し、役職を剥奪します。", Color.ORANGE);
+                if (!dryRun) {
+                    disableLink(mdc, uuid);
+                    guild.removeRoleFromMember(member, MinecraftConnectedRole).queue();
+                }
+                isMinecraftConnected = false;
+            }
+            if (isMinecraftConnected && isSubAccount) {
+                if (!dryRun) {
+                    guild.removeRoleFromMember(member, SubAccountRole).queue();
+                }
+            }
+        } else {
+            // MinecraftConnected役職がついていない場合、Verified, Community Regular, Regular役職を剥奪する
+            if (isVerified) {
+                notifyConnection(member, "Verified役職剥奪", "linkが解除されているため、Verified役職を剥奪しました。", Color.GREEN);
+                if (!dryRun) guild.removeRoleFromMember(member, VerifiedRole).queue();
+            }
+            if (isCommunityRegular) {
+                notifyConnection(member, "CommunityRegular役職剥奪", "linkが解除されているため、CommunityRegular役職を剥奪しました。", Color.GREEN);
+                if (!dryRun) guild.removeRoleFromMember(member, CommunityRegularRole).queue();
+            }
+            if (isRegular) {
+                notifyConnection(member, "Regular役職剥奪", "linkが解除されているため、Regular役職を剥奪しました。", Color.GREEN);
+                if (!dryRun) guild.removeRoleFromMember(member, RegularRole).queue();
+            }
+        }
+    }
+
+    Timestamp getMaxTimestamp(Timestamp a, Timestamp b) {
+        if (a.before(b)) {
+            return b;
+        } else if (b.before(a)) {
+            return a;
+        } else if (a.equals(b)) {
+            return a;
+        }
+        return null;
+    }
+
+    private List<MinecraftDiscordConnection> getConnections() {
+        List<MinecraftDiscordConnection> connections = new ArrayList<>();
+        try {
+            try (PreparedStatement statement = conn.prepareStatement("SELECT * FROM discordlink")) {
+                statement.setBoolean(1, false);
+                try (ResultSet res = statement.executeQuery()) {
+                    connections.add(new MinecraftDiscordConnection(
+                        res.getString("player"),
+                        UUID.fromString(res.getString("uuid")),
+                        res.getString("disid"),
+                        res.getString("discriminator"),
+                        getLeastLogin(UUID.fromString(res.getString("uuid"))),
+                        res.getTimestamp("expired_date"),
+                        res.getTimestamp("dead_at"),
+                        res.getBoolean("disabled")
+                    ));
+                }
+            }
+            return connections;
+        } catch (SQLException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    private Timestamp getLeastLogin(UUID uuid) {
+        try (PreparedStatement stmt = conn.prepareStatement("SELECT * FROM login WHERE uuid = ? AND login_success = ? ORDER BY id DESC LIMIT 1")) {
+            stmt.setString(1, uuid.toString());
+            stmt.setBoolean(2, true);
+            ResultSet result = stmt.executeQuery();
+            if (!result.next()) {
+                return null;
+            }
+            return result.getTimestamp("date");
+        } catch (SQLException e) {
+            return null;
+        }
+    }
+
+    private boolean isGrantedRole(Member member, Role role, String roleName) {
+        boolean isGranted = member
+            .getRoles()
+            .stream()
+            .map(ISnowflake::getIdLong)
+            .anyMatch(i -> role.getIdLong() == i);
+        if (isGranted) {
+            logger.info("[%s] %s".formatted(
+                member.getUser().getAsTag(),
+                "is%s: true".formatted(roleName)
+            ));
+        }
+        return isGranted;
+    }
+
+    private void notifyConnection(Member member, String title, String description, Color color) {
+        TextChannel channel = Main.getJDA().getTextChannelById(891021520099500082L);
+        if (channel == null) {
+            return;
+        }
+        EmbedBuilder embed = new EmbedBuilder()
+            .setTitle(title)
+            .setDescription(description)
+            .setColor(color)
+            .setAuthor(member.getUser().getAsTag(), "https://discord.com/users/" + member.getId(), member.getUser().getEffectiveAvatarUrl());
+        if (dryRun) {
+            embed.setFooter("DRY-RUN MODE");
+        }
+        channel
+            .sendMessageEmbeds(embed.build())
+            .queue();
+    }
+
+    private PermissionGroup getPermissionGroup(UUID uuid) {
+        try {
+            try (PreparedStatement statement = conn.prepareStatement("SELECT * FROM permissions WHERE uuid = ?")) {
+                statement.setString(1, uuid.toString());
+                try (ResultSet res = statement.executeQuery()) {
+                    if (!res.next()) {
+                        return null;
+                    }
+                    String permissionGroup = res.getString("permission");
+                    return Arrays
+                        .stream(PermissionGroup.values())
+                        .filter(p -> p.name().equalsIgnoreCase(permissionGroup))
+                        .findFirst()
+                        .orElse(PermissionGroup.UNKNOWN);
+                }
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    private void kickDiscord(Member member, String title, String description, Color color) {
+        Path path = Path.of("pre-permsync.json");
+        JSONObject object = new JSONObject();
+        if (Files.exists(path)) {
+            try {
+                object = new JSONObject(Files.readString(path));
+            } catch (IOException e) {
+                logger.warn("grantDiscordPerm json load failed.", e);
+                return;
+            }
+        }
+        if (!object.has("kick")) {
+            object.put("kick", new JSONObject());
+        }
+        JSONArray kicks = object.getJSONArray("kick");
+
+        if (kicks
+            .toList()
+            .contains(member.getId())) {
+            // 処理
+            notifyConnection(member, "[PROCESS] " + title, description, color);
+            member.getGuild().kick(member).queue();
+            kicks.remove(kicks.toList().indexOf(member.getId()));
+        } else {
+            // 動作予告
+            notifyConnection(member, "[PRE] " + title, "次回処理時、本動作が実施されます。", color);
+            kicks.put(member.getId());
+        }
+
+        object.put("kick", kicks);
+        try {
+            Files.writeString(path, object.toString());
+        } catch (IOException e) {
+            logger.warn("grantDiscordPerm json save failed.", e);
+        }
+    }
+
+    private void disableLink(MinecraftDiscordConnection mdc, UUID uuid) {
+        try (PreparedStatement stmt = conn.prepareStatement("UPDATE discordlink SET disabled = ? WHERE uuid = ? AND disabled = ?")) {
+            stmt.setBoolean(1, true);
+            stmt.setString(2, uuid.toString());
+            stmt.setBoolean(3, true);
+            stmt.execute();
+        } catch (SQLException e) {
+            logger.warn("disableLink(%s): failed".formatted(mdc.player + "#" + mdc.uuid), e);
+        }
+    }
+
+    record MinecraftDiscordConnection(String player, UUID uuid, String disid, String discriminator, Timestamp loginDate,
+                                      Timestamp expired_date, Timestamp dead_at, boolean disabled) {
+
+    }
+
+    enum PermissionGroup {
+        ADMIN,
+        MODERATOR,
+        REGULAR,
+        VERIFIED,
+        DEFAULT,
+        UNKNOWN
+    }
+
+    class Notified {
+        Path path = Path.of("permsync-notified.json");
+        Member member;
+
+        Notified(Member member) {
+            this.member = member;
+        }
+
+        private boolean isNotified(NotifiedType type) {
+            JSONObject object = load();
+            return object.has(member.getId()) && object.getJSONObject(member.getId()).has(type.name());
+        }
+
+        private void setNotified(NotifiedType type) {
+            JSONObject object = load();
+            JSONArray userObject = object.has(member.getId()) ? object.getJSONArray(member.getId()) : new JSONArray();
+            userObject.put(type.name());
+            object.put(member.getId(), userObject);
+            try {
+                Files.writeString(path, object.toString());
+            } catch (IOException e) {
+                logger.warn("Notified.setNotified is failed.", e);
+            }
+        }
+
+        private JSONObject load() {
+            JSONObject object = new JSONObject();
+            if (Files.exists(path)) {
+                try {
+                    object = new JSONObject(Files.readString(path));
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+            return object;
+        }
+
+
+        enum NotifiedType {
+            MONTH2
+        }
+    }
+}


### PR DESCRIPTION
- close #65 

以下の処理を実装

```java
/**
 * Minecraft-Discord Connect(/link) に基づき、以下の利用者整理処理を行う
 * ここでの1ヶ月は30日とする。
 * (dryRun引数がTrueの場合は対象のメンバーのみを抽出)
 * <p>
 * - 参加してから10分以内に発言のないユーザーをキックする
 * - 参加してから1週間以内にlink・サブアカウント登録・サポートへの問い合わせがない場合はキックする
 * - 参加してから3週間後にサポート問い合わせのみの場合はキックする
 * - linkされているのに、Guildにいない利用者のlinkを解除する
 * - Minecraft-Discord Connectがなされていて、MinecraftConnected役職か付与されていない利用者に対して、MinecraftConnected役職を付与する
 * - Minecraft-Discord Connectがなされておらず、MinecraftConnected役職か付与されている利用者に対して、MinecraftConnected役職を剥奪する
 * - MinecraftConnected役職がついている場合、Verified, Regularの役職に応じて役職を付与する
 * - MinecraftConnected役職がついていない場合、Verified, Community Regular, Regular役職を剥奪する
 * - 最終ログインから2ヶ月が経過している場合、警告リプライを#generalで送信する
 * - 最終ログインから3ヶ月が経過している場合、linkをdisabledにし、MinecraftConnected権限を剥奪する
 * - メインアカウントが1か月以上前に退出しているのにも関わらず、SubAccount役職がついている利用者から本役職を外す。
 * <p>
 * - 解除関連処理時、ExpiredDateが設定されている場合は、期限日は最終ログインから3ヶ月後かExpiredDateのいずれか遅い方を使用する
 * <p>
 */
```

https://github.com/book000/Javajaotan2/blob/008f720b211eda92965a7cc44a314a3fc6c70387/src/main/java/com/jaoafa/javajaotan2/tasks/Task_PermSync.java#L41-L60