### PR TITLE
feat: Nitrotanの付与・剥奪を作り直した(作り終えた)。いくつかのバグを修正

### DIFF
--- a/src/main/java/com/jaoafa/javajaotan2/event/Event_CheckNitroEmoji.java
+++ b/src/main/java/com/jaoafa/javajaotan2/event/Event_CheckNitroEmoji.java
@@ -1,0 +1,127 @@
+/*
+ * jaoLicense
+ *
+ * Copyright (c) 2021 jao Minecraft Server
+ *
+ * The following license applies to this project: jaoLicense
+ *
+ * Japanese: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE.md
+ * English: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE-en.md
+ */
+
+package com.jaoafa.javajaotan2.event;
+
+import com.jaoafa.javajaotan2.Main;
+import com.jaoafa.javajaotan2.lib.JavajaotanLibrary;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.*;
+import net.dv8tion.jda.api.events.emote.EmoteAddedEvent;
+import net.dv8tion.jda.api.events.emote.EmoteRemovedEvent;
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import org.jetbrains.annotations.NotNull;
+import org.json.JSONObject;
+
+import javax.annotation.Nonnull;
+import java.awt.*;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Date;
+import java.util.List;
+
+public class Event_CheckNitroEmoji extends ListenerAdapter {
+    List<ListedEmote> guildEmojis = null;
+
+    @Override
+    public void onMessageReceived(@Nonnull MessageReceivedEvent event) {
+        if (Main.getConfig().getGuildId() != event.getGuild().getIdLong()) {
+            return;
+        }
+        Message message = event.getMessage();
+        Member member = event.getMember();
+        if (member == null) {
+            return;
+        }
+        Guild guild = event.getGuild();
+        if (guildEmojis == null) {
+            guildEmojis = guild.retrieveEmotes().complete();
+        }
+
+        List<Emote> emotes = message.getEmotes();
+        // GIF絵文字を使用しているか
+        boolean usingAnimated = emotes.stream().anyMatch(Emote::isAnimated);
+        // いずれかの絵文字が、このGuildにはない絵文字を利用しているかどうか
+        boolean isOtherGuildEmoji = emotes
+            .stream()
+            .anyMatch(e -> guildEmojis
+                .stream()
+                .noneMatch(guildEmoji -> guildEmoji.getIdLong() == e.getIdLong()));
+
+        Role roleNitrotan = guild.getRoleById(795153241385861130L);
+        if (roleNitrotan == null) {
+            Main.getLogger().error("Nitrotan role is not found");
+            return;
+        }
+
+        if (!usingAnimated && !isOtherGuildEmoji) {
+            return;
+        }
+        boolean isNitrotan = JavajaotanLibrary.isGrantedRole(member, roleNitrotan);
+
+        if (!isNitrotan) {
+            String title = usingAnimated ? "usingAnimated" : "isOtherGuildEmoji";
+            String desc = usingAnimated ? "アニメーション絵文字を使用した投稿を行ったため、" : "外部サーバの絵文字を使用した投稿を行ったため、";
+            notifyConnection(member, "Nitrotan役職付与 (%s)".formatted(title), "%sNitrotan役職を付与しました。".formatted(desc));
+            guild.addRoleToMember(member, roleNitrotan).queue();
+        }
+
+        Path path = Path.of("nitrotan.json");
+        try {
+            JSONObject object = new JSONObject();
+            if (Files.exists(path)) {
+                object = new JSONObject(Files.readString(path));
+            }
+            object.put(member.getId(), new Date().getTime());
+            Files.writeString(path, object.toString());
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public void onEmoteAdded(@NotNull EmoteAddedEvent event) {
+        if (Main.getConfig().getGuildId() != event.getGuild().getIdLong()) {
+            return;
+        }
+        event.getGuild().retrieveEmotes().queue(
+            emojis -> guildEmojis = emojis,
+            Throwable::printStackTrace
+        );
+    }
+
+    @Override
+    public void onEmoteRemoved(@NotNull EmoteRemovedEvent event) {
+        if (Main.getConfig().getGuildId() != event.getGuild().getIdLong()) {
+            return;
+        }
+        event.getGuild().retrieveEmotes().queue(
+            emojis -> guildEmojis = emojis,
+            Throwable::printStackTrace
+        );
+    }
+
+    private void notifyConnection(Member member, String title, String description) {
+        TextChannel channel = Main.getJDA().getTextChannelById(891021520099500082L);
+
+        if (channel == null) return;
+
+        EmbedBuilder embed = new EmbedBuilder()
+            .setTitle(title)
+            .setDescription(description)
+            .setColor(Color.LIGHT_GRAY)
+            .setAuthor(member.getUser().getAsTag(), "https://discord.com/users/" + member.getId(), member.getUser().getEffectiveAvatarUrl());
+
+        channel.sendMessageEmbeds(embed.build()).queue();
+    }
+}

--- a/src/main/java/com/jaoafa/javajaotan2/tasks/Task_MemberOrganize.java
+++ b/src/main/java/com/jaoafa/javajaotan2/tasks/Task_MemberOrganize.java
@@ -413,7 +413,7 @@ public class Task_MemberOrganize implements Job {
             try (PreparedStatement stmt = conn.prepareStatement("UPDATE discordlink SET disabled = ? WHERE uuid = ? AND disabled = ?")) {
                 stmt.setBoolean(1, true);
                 stmt.setString(2, uuid.toString());
-                stmt.setBoolean(3, true);
+                stmt.setBoolean(3, false);
                 stmt.execute();
             } catch (SQLException e) {
                 logger.warn("disableLink(%s): failed".formatted(mdc.player + "#" + mdc.uuid), e);

--- a/src/main/java/com/jaoafa/javajaotan2/tasks/Task_PermSync.java
+++ b/src/main/java/com/jaoafa/javajaotan2/tasks/Task_PermSync.java
@@ -22,19 +22,22 @@ import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.entities.TextChannel;
+import org.json.JSONObject;
 import org.quartz.Job;
 import org.quartz.JobExecutionContext;
 import org.slf4j.Logger;
 
 import java.awt.*;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.sql.*;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.BiFunction;
@@ -46,13 +49,14 @@ import java.util.stream.Collectors;
  * - MinecraftConnected役職がついている場合、Verified, Regularの役職に応じて役職を付与する
  * - MinecraftConnected役職がついていない場合、Verified, Community Regular, Regular役職を剥奪する
  * - Nitroの場合(gif画像がアイコンの場合)、Nitrotanを付与する
+ * - Nitrotan役職がついていて、GIFアイコンでなく、アニメーション/外部絵文字の最終メッセージ送信日時が1週間前の場合、Nitrotan役職を剥奪する
  */
 public class Task_PermSync implements Job {
     final boolean dryRun;
     Logger logger;
     Connection conn;
-
     TextChannel Channel_General;
+    JSONObject nitrotan = new JSONObject();
 
     public Task_PermSync() {
         this.dryRun = false;
@@ -90,10 +94,18 @@ public class Task_PermSync implements Job {
         Roles.setGuildAndRole(guild);
 
         Channel_General = Channels.general.getChannel();
-
         if (Channel_General == null) {
             logger.warn("Channel_General == null");
             return;
+        }
+
+        Path path = Path.of("nitrotan.json");
+        try {
+            if (Files.exists(path)) {
+                nitrotan = new JSONObject(Files.readString(path));
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
         }
 
         ExecutorService service = Executors.newFixedThreadPool(10,
@@ -189,8 +201,18 @@ public class Task_PermSync implements Job {
             boolean isSubAccount = JavajaotanLibrary.isGrantedRole(member, Roles.SubAccount.role);
             boolean isNitrotan = JavajaotanLibrary.isGrantedRole(member, Roles.Nitrotan.role);
 
+            // Nitroの場合(gif画像がアイコンの場合)、Nitrotanを付与する
             if (member.getUser().getEffectiveAvatarUrl().endsWith(".gif") && !isNitrotan) {
                 notifyConnection(member, "Nitrotan役職付与", "アイコンがGIF画像だったので、Nitrotan役職を付与しました。", Color.LIGHT_GRAY, mdc);
+                if (!dryRun) guild.addRoleToMember(member, Roles.Nitrotan.role).queue();
+                isNitrotan = true;
+            }
+            // Nitrotan役職がついていて、GIFアイコンでなく、アニメーション/外部絵文字の最終メッセージ送信日時が1週間前の場合、Nitrotan役職を剥奪する
+            // アニメーション/外部絵文字の最終メッセージ送信日時が何ミリ秒前か？
+            long lastNitroAgo = nitrotan.has(member.getId()) ? new Date().getTime() - nitrotan.getLong(member.getId()) : -1;
+            // 7日 * 24時間 * 60分 * 60秒 * 1000秒
+            if (isNitrotan && !member.getUser().getEffectiveAvatarUrl().endsWith(".gif") && (lastNitroAgo == -1 || lastNitroAgo > 7 * 24 * 60 * 60 * 1000)) {
+                notifyConnection(member, "Nitrotan役職剥奪", "アイコンがGIF画像ではなく、またアニメーション/外部絵文字を使用したメッセージが1週間以上前だったためNitrotan役職を剥奪しました。", Color.LIGHT_GRAY, mdc);
                 if (!dryRun) guild.addRoleToMember(member, Roles.Nitrotan.role).queue();
             }
 
@@ -221,7 +243,13 @@ public class Task_PermSync implements Job {
             //giveRole,description,isMinecraftConnected
             BiFunction<Boolean, String, Boolean> doMinecraftConnectedManage = (giveRole, description) -> {
                 notifyConnection(member, "MinecraftConnected役職" + (giveRole ? "付与" : "剥奪"), description, Color.BLUE, mdc);
-                if (!dryRun) guild.addRoleToMember(member, Roles.MinecraftConnected.role).queue();
+                if (!dryRun) {
+                    if (giveRole) {
+                        guild.addRoleToMember(member, Roles.MinecraftConnected.role).queue();
+                    } else {
+                        guild.removeRoleFromMember(member, Roles.MinecraftConnected.role).queue();
+                    }
+                }
                 return true;
             };
 


### PR DESCRIPTION
- close #86 

## Nitrotan

- アニメーション絵文字 or 外部絵文字を含むメッセージ投稿を行った場合、(Nitrotanがついていなければ)Nitrotan役職を付与する。また、その日時を保存しておく
- Nitrotanで、最後のアニメーション絵文字 or 外部絵文字を含むメッセージ投稿から1週間を経過していて、またアイコンがGIF画像でない場合はNitrotan役職を剥奪する

## その他

- 外部鯖メンバーの役職連携を実施するように(dryRun false)
- MinecraftConnectedを剥奪する際の処理にバグ
  - linkが切断されない (SQL文が間違ってた)
  - MinecraftConnected役職が外れない(elseが書いてなかった)