### PR TITLE
feat: #115 翻訳コマンドの追加

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,5 +143,16 @@
             <artifactId>guava</artifactId>
             <version>31.0.1-jre</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.8.1</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.detectlanguage</groupId>
+            <artifactId>detectlanguage</artifactId>
+            <version>1.1.0</version>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/com/jaoafa/javajaotan2/Main.java
+++ b/src/main/java/com/jaoafa/javajaotan2/Main.java
@@ -60,15 +60,13 @@ public class Main {
     static boolean isGuildDevelopMode = false;
     static long developUserId;
     static long developGuildId;
-    static Logger logger;
+    static Logger logger = LoggerFactory.getLogger("Javajaotan2");
     static JavajaotanConfig config;
     static JDA jda;
     static JSONArray commands;
     static WatchEmojis watchEmojis;
 
     public static void main(String[] args) {
-        logger = LoggerFactory.getLogger("Javajaotan2");
-
         isUserDevelopMode = new File("../build.json").exists();
         if (isUserDevelopMode) {
             try {
@@ -483,6 +481,10 @@ public class Main {
 
     public static JavajaotanConfig getConfig() {
         return config;
+    }
+
+    public static void setConfig(JavajaotanConfig config) {
+        Main.config = config;
     }
 
     public static JDA getJDA() {

--- a/src/main/java/com/jaoafa/javajaotan2/command/Cmd_ToAr.java
+++ b/src/main/java/com/jaoafa/javajaotan2/command/Cmd_ToAr.java
@@ -49,7 +49,7 @@ public class Cmd_ToAr implements CommandPremise {
         String text = context.get("text");
 
         Translate.TranslateResult result = Translate.translate(
-            Translate.Language.AUTO,
+            Translate.Language.UNKNOWN,
             Translate.Language.AR,
             text
         );

--- a/src/main/java/com/jaoafa/javajaotan2/command/Cmd_ToAr.java
+++ b/src/main/java/com/jaoafa/javajaotan2/command/Cmd_ToAr.java
@@ -1,0 +1,67 @@
+/*
+ * jaoLicense
+ *
+ * Copyright (c) 2021 jao Minecraft Server
+ *
+ * The following license applies to this project: jaoLicense
+ *
+ * Japanese: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE.md
+ * English: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE-en.md
+ */
+
+package com.jaoafa.javajaotan2.command;
+
+import cloud.commandframework.Command;
+import cloud.commandframework.arguments.standard.StringArgument;
+import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.jda.JDACommandSender;
+import cloud.commandframework.meta.CommandMeta;
+import com.jaoafa.javajaotan2.lib.CommandPremise;
+import com.jaoafa.javajaotan2.lib.JavajaotanCommand;
+import com.jaoafa.javajaotan2.lib.Translate;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageChannel;
+import org.jetbrains.annotations.NotNull;
+
+public class Cmd_ToAr implements CommandPremise {
+    @Override
+    public JavajaotanCommand.Detail details() {
+        return new JavajaotanCommand.Detail(
+            "tosw",
+            "Google翻訳を用いてアラビア文字へ翻訳を行います。"
+        );
+    }
+
+    @Override
+    public JavajaotanCommand.Cmd register(Command.Builder<JDACommandSender> builder) {
+        return new JavajaotanCommand.Cmd(
+            builder
+                .meta(CommandMeta.DESCRIPTION, "Google翻訳を用いてアラビア文字へ翻訳を行います。")
+                .argument(StringArgument.greedy("text"))
+                .handler(context -> execute(context, this::translateAr))
+                .build()
+        );
+    }
+
+    private void translateAr(@NotNull Guild guild, @NotNull MessageChannel channel, @NotNull Member member, @NotNull Message message, @NotNull CommandContext<JDACommandSender> context) {
+        String text = context.get("text");
+
+        Translate.TranslateResult result = Translate.translate(
+            Translate.Language.AUTO,
+            Translate.Language.AR,
+            text
+        );
+        if (result == null) {
+            message.reply("翻訳に失敗しました。").queue();
+            return;
+        }
+
+        message.reply("```%s```\n`%s` -> `%s`".formatted(
+            result.result(),
+            result.from().toString(),
+            result.to().toString()
+        )).queue();
+    }
+}

--- a/src/main/java/com/jaoafa/javajaotan2/command/Cmd_ToArJa.java
+++ b/src/main/java/com/jaoafa/javajaotan2/command/Cmd_ToArJa.java
@@ -1,0 +1,90 @@
+/*
+ * jaoLicense
+ *
+ * Copyright (c) 2021 jao Minecraft Server
+ *
+ * The following license applies to this project: jaoLicense
+ *
+ * Japanese: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE.md
+ * English: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE-en.md
+ */
+
+package com.jaoafa.javajaotan2.command;
+
+import cloud.commandframework.Command;
+import cloud.commandframework.arguments.standard.StringArgument;
+import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.jda.JDACommandSender;
+import cloud.commandframework.meta.CommandMeta;
+import com.jaoafa.javajaotan2.lib.CommandPremise;
+import com.jaoafa.javajaotan2.lib.JavajaotanCommand;
+import com.jaoafa.javajaotan2.lib.Translate;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageChannel;
+import org.jetbrains.annotations.NotNull;
+
+import java.awt.*;
+import java.time.Instant;
+
+public class Cmd_ToArJa implements CommandPremise {
+    @Override
+    public JavajaotanCommand.Detail details() {
+        return new JavajaotanCommand.Detail(
+            "toswja",
+            "Google翻訳を用いてアラビア文字へ翻訳をしたあと、日本語へ翻訳を行います。"
+        );
+    }
+
+    @Override
+    public JavajaotanCommand.Cmd register(Command.Builder<JDACommandSender> builder) {
+        return new JavajaotanCommand.Cmd(
+            builder
+                .meta(CommandMeta.DESCRIPTION, "Google翻訳を用いてアラビア文字へ翻訳をしたあと、日本語へ翻訳を行います。")
+                .argument(StringArgument.greedy("text"))
+                .handler(context -> execute(context, this::translateArJa))
+                .build()
+        );
+    }
+
+    private void translateArJa(@NotNull Guild guild, @NotNull MessageChannel channel, @NotNull Member member, @NotNull Message message, @NotNull CommandContext<JDACommandSender> context) {
+        String text = context.get("text");
+
+        Translate.Language lang1 = Translate.Language.AR;
+        Translate.Language lang2 = Translate.Language.JA;
+
+        Translate.TranslateResult result1 = Translate.translate(
+            Translate.Language.UNKNOWN,
+            lang1,
+            text
+        );
+        if (result1 == null) {
+            message.reply("翻訳に失敗しました。").queue();
+            return;
+        }
+
+        Translate.TranslateResult result2 = Translate.translate(
+            lang1,
+            lang2,
+            text
+        );
+        if (result2 == null) {
+            message.reply("翻訳に失敗しました。").queue();
+            return;
+        }
+
+        EmbedBuilder embed = new EmbedBuilder()
+            .setTitle("翻訳が成功しました:clap:")
+            .addField("`%s` -> `%s`".formatted(result1.from().toString(), lang1.toString()),
+                "```%s```".formatted(text),
+                false)
+            .addField("`%s` -> `%s`".formatted(lang1.toString(), lang2.toString()),
+                "```%s```".formatted(text),
+                false)
+            .setColor(Color.PINK)
+            .setTimestamp(Instant.now());
+        message.replyEmbeds(embed.build()).queue();
+    }
+}

--- a/src/main/java/com/jaoafa/javajaotan2/command/Cmd_ToArJa.java
+++ b/src/main/java/com/jaoafa/javajaotan2/command/Cmd_ToArJa.java
@@ -78,11 +78,11 @@ public class Cmd_ToArJa implements CommandPremise {
         EmbedBuilder embed = new EmbedBuilder()
             .setTitle("翻訳が成功しました:clap:")
             .addField("`%s` -> `%s`".formatted(result1.from().toString(), lang1.toString()),
-                "```%s```".formatted(text),
-                false)
+                "```%s```".formatted(result1.result()),
+                true)
             .addField("`%s` -> `%s`".formatted(lang1.toString(), lang2.toString()),
-                "```%s```".formatted(text),
-                false)
+                "```%s```".formatted(result2.result()),
+                true)
             .setColor(Color.PINK)
             .setTimestamp(Instant.now());
         message.replyEmbeds(embed.build()).queue();

--- a/src/main/java/com/jaoafa/javajaotan2/command/Cmd_ToEn.java
+++ b/src/main/java/com/jaoafa/javajaotan2/command/Cmd_ToEn.java
@@ -1,0 +1,67 @@
+/*
+ * jaoLicense
+ *
+ * Copyright (c) 2021 jao Minecraft Server
+ *
+ * The following license applies to this project: jaoLicense
+ *
+ * Japanese: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE.md
+ * English: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE-en.md
+ */
+
+package com.jaoafa.javajaotan2.command;
+
+import cloud.commandframework.Command;
+import cloud.commandframework.arguments.standard.StringArgument;
+import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.jda.JDACommandSender;
+import cloud.commandframework.meta.CommandMeta;
+import com.jaoafa.javajaotan2.lib.CommandPremise;
+import com.jaoafa.javajaotan2.lib.JavajaotanCommand;
+import com.jaoafa.javajaotan2.lib.Translate;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageChannel;
+import org.jetbrains.annotations.NotNull;
+
+public class Cmd_ToEn implements CommandPremise {
+    @Override
+    public JavajaotanCommand.Detail details() {
+        return new JavajaotanCommand.Detail(
+            "toen",
+            "Google翻訳を用いて英語へ翻訳を行います。"
+        );
+    }
+
+    @Override
+    public JavajaotanCommand.Cmd register(Command.Builder<JDACommandSender> builder) {
+        return new JavajaotanCommand.Cmd(
+            builder
+                .meta(CommandMeta.DESCRIPTION, "Google翻訳を用いて英語へ翻訳を行います。")
+                .argument(StringArgument.greedy("text"))
+                .handler(context -> execute(context, this::translateEn))
+                .build()
+        );
+    }
+
+    private void translateEn(@NotNull Guild guild, @NotNull MessageChannel channel, @NotNull Member member, @NotNull Message message, @NotNull CommandContext<JDACommandSender> context) {
+        String text = context.get("text");
+
+        Translate.TranslateResult result = Translate.translate(
+            Translate.Language.AUTO,
+            Translate.Language.EN,
+            text
+        );
+        if (result == null) {
+            message.reply("翻訳に失敗しました。").queue();
+            return;
+        }
+
+        message.reply("```%s```\n`%s` -> `%s`".formatted(
+            result.result(),
+            result.from().toString(),
+            result.to().toString()
+        )).queue();
+    }
+}

--- a/src/main/java/com/jaoafa/javajaotan2/command/Cmd_ToEn.java
+++ b/src/main/java/com/jaoafa/javajaotan2/command/Cmd_ToEn.java
@@ -49,7 +49,7 @@ public class Cmd_ToEn implements CommandPremise {
         String text = context.get("text");
 
         Translate.TranslateResult result = Translate.translate(
-            Translate.Language.AUTO,
+            Translate.Language.UNKNOWN,
             Translate.Language.EN,
             text
         );

--- a/src/main/java/com/jaoafa/javajaotan2/command/Cmd_ToEnJa.java
+++ b/src/main/java/com/jaoafa/javajaotan2/command/Cmd_ToEnJa.java
@@ -78,11 +78,11 @@ public class Cmd_ToEnJa implements CommandPremise {
         EmbedBuilder embed = new EmbedBuilder()
             .setTitle("翻訳が成功しました:clap:")
             .addField("`%s` -> `%s`".formatted(result1.from().toString(), lang1.toString()),
-                "```%s```".formatted(text),
-                false)
+                "```%s```".formatted(result1.result()),
+                true)
             .addField("`%s` -> `%s`".formatted(lang1.toString(), lang2.toString()),
-                "```%s```".formatted(text),
-                false)
+                "```%s```".formatted(result2.result()),
+                true)
             .setColor(Color.PINK)
             .setTimestamp(Instant.now());
         message.replyEmbeds(embed.build()).queue();

--- a/src/main/java/com/jaoafa/javajaotan2/command/Cmd_ToEnJa.java
+++ b/src/main/java/com/jaoafa/javajaotan2/command/Cmd_ToEnJa.java
@@ -1,0 +1,90 @@
+/*
+ * jaoLicense
+ *
+ * Copyright (c) 2021 jao Minecraft Server
+ *
+ * The following license applies to this project: jaoLicense
+ *
+ * Japanese: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE.md
+ * English: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE-en.md
+ */
+
+package com.jaoafa.javajaotan2.command;
+
+import cloud.commandframework.Command;
+import cloud.commandframework.arguments.standard.StringArgument;
+import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.jda.JDACommandSender;
+import cloud.commandframework.meta.CommandMeta;
+import com.jaoafa.javajaotan2.lib.CommandPremise;
+import com.jaoafa.javajaotan2.lib.JavajaotanCommand;
+import com.jaoafa.javajaotan2.lib.Translate;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageChannel;
+import org.jetbrains.annotations.NotNull;
+
+import java.awt.*;
+import java.time.Instant;
+
+public class Cmd_ToEnJa implements CommandPremise {
+    @Override
+    public JavajaotanCommand.Detail details() {
+        return new JavajaotanCommand.Detail(
+            "toenja",
+            "Google翻訳を用いて英語へ翻訳をしたあと、日本語へ翻訳を行います。"
+        );
+    }
+
+    @Override
+    public JavajaotanCommand.Cmd register(Command.Builder<JDACommandSender> builder) {
+        return new JavajaotanCommand.Cmd(
+            builder
+                .meta(CommandMeta.DESCRIPTION, "Google翻訳を用いて英語へ翻訳をしたあと、日本語へ翻訳を行います。")
+                .argument(StringArgument.greedy("text"))
+                .handler(context -> execute(context, this::translateEnJa))
+                .build()
+        );
+    }
+
+    private void translateEnJa(@NotNull Guild guild, @NotNull MessageChannel channel, @NotNull Member member, @NotNull Message message, @NotNull CommandContext<JDACommandSender> context) {
+        String text = context.get("text");
+
+        Translate.Language lang1 = Translate.Language.EN;
+        Translate.Language lang2 = Translate.Language.JA;
+
+        Translate.TranslateResult result1 = Translate.translate(
+            Translate.Language.UNKNOWN,
+            lang1,
+            text
+        );
+        if (result1 == null) {
+            message.reply("翻訳に失敗しました。").queue();
+            return;
+        }
+
+        Translate.TranslateResult result2 = Translate.translate(
+            lang1,
+            lang2,
+            text
+        );
+        if (result2 == null) {
+            message.reply("翻訳に失敗しました。").queue();
+            return;
+        }
+
+        EmbedBuilder embed = new EmbedBuilder()
+            .setTitle("翻訳が成功しました:clap:")
+            .addField("`%s` -> `%s`".formatted(result1.from().toString(), lang1.toString()),
+                "```%s```".formatted(text),
+                false)
+            .addField("`%s` -> `%s`".formatted(lang1.toString(), lang2.toString()),
+                "```%s```".formatted(text),
+                false)
+            .setColor(Color.PINK)
+            .setTimestamp(Instant.now());
+        message.replyEmbeds(embed.build()).queue();
+    }
+}

--- a/src/main/java/com/jaoafa/javajaotan2/command/Cmd_ToHe.java
+++ b/src/main/java/com/jaoafa/javajaotan2/command/Cmd_ToHe.java
@@ -49,7 +49,7 @@ public class Cmd_ToHe implements CommandPremise {
         String text = context.get("text");
 
         Translate.TranslateResult result = Translate.translate(
-            Translate.Language.AUTO,
+            Translate.Language.UNKNOWN,
             Translate.Language.HE,
             text
         );

--- a/src/main/java/com/jaoafa/javajaotan2/command/Cmd_ToHe.java
+++ b/src/main/java/com/jaoafa/javajaotan2/command/Cmd_ToHe.java
@@ -1,0 +1,67 @@
+/*
+ * jaoLicense
+ *
+ * Copyright (c) 2021 jao Minecraft Server
+ *
+ * The following license applies to this project: jaoLicense
+ *
+ * Japanese: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE.md
+ * English: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE-en.md
+ */
+
+package com.jaoafa.javajaotan2.command;
+
+import cloud.commandframework.Command;
+import cloud.commandframework.arguments.standard.StringArgument;
+import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.jda.JDACommandSender;
+import cloud.commandframework.meta.CommandMeta;
+import com.jaoafa.javajaotan2.lib.CommandPremise;
+import com.jaoafa.javajaotan2.lib.JavajaotanCommand;
+import com.jaoafa.javajaotan2.lib.Translate;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageChannel;
+import org.jetbrains.annotations.NotNull;
+
+public class Cmd_ToHe implements CommandPremise {
+    @Override
+    public JavajaotanCommand.Detail details() {
+        return new JavajaotanCommand.Detail(
+            "tosw",
+            "Google翻訳を用いてヘブライ語へ翻訳を行います。"
+        );
+    }
+
+    @Override
+    public JavajaotanCommand.Cmd register(Command.Builder<JDACommandSender> builder) {
+        return new JavajaotanCommand.Cmd(
+            builder
+                .meta(CommandMeta.DESCRIPTION, "Google翻訳を用いてヘブライ語へ翻訳を行います。")
+                .argument(StringArgument.greedy("text"))
+                .handler(context -> execute(context, this::translateHe))
+                .build()
+        );
+    }
+
+    private void translateHe(@NotNull Guild guild, @NotNull MessageChannel channel, @NotNull Member member, @NotNull Message message, @NotNull CommandContext<JDACommandSender> context) {
+        String text = context.get("text");
+
+        Translate.TranslateResult result = Translate.translate(
+            Translate.Language.AUTO,
+            Translate.Language.HE,
+            text
+        );
+        if (result == null) {
+            message.reply("翻訳に失敗しました。").queue();
+            return;
+        }
+
+        message.reply("```%s```\n`%s` -> `%s`".formatted(
+            result.result(),
+            result.from().toString(),
+            result.to().toString()
+        )).queue();
+    }
+}

--- a/src/main/java/com/jaoafa/javajaotan2/command/Cmd_ToHeJa.java
+++ b/src/main/java/com/jaoafa/javajaotan2/command/Cmd_ToHeJa.java
@@ -1,0 +1,90 @@
+/*
+ * jaoLicense
+ *
+ * Copyright (c) 2021 jao Minecraft Server
+ *
+ * The following license applies to this project: jaoLicense
+ *
+ * Japanese: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE.md
+ * English: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE-en.md
+ */
+
+package com.jaoafa.javajaotan2.command;
+
+import cloud.commandframework.Command;
+import cloud.commandframework.arguments.standard.StringArgument;
+import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.jda.JDACommandSender;
+import cloud.commandframework.meta.CommandMeta;
+import com.jaoafa.javajaotan2.lib.CommandPremise;
+import com.jaoafa.javajaotan2.lib.JavajaotanCommand;
+import com.jaoafa.javajaotan2.lib.Translate;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageChannel;
+import org.jetbrains.annotations.NotNull;
+
+import java.awt.*;
+import java.time.Instant;
+
+public class Cmd_ToHeJa implements CommandPremise {
+    @Override
+    public JavajaotanCommand.Detail details() {
+        return new JavajaotanCommand.Detail(
+            "toswja",
+            "Google翻訳を用いてヘブライ語へ翻訳をしたあと、日本語へ翻訳を行います。"
+        );
+    }
+
+    @Override
+    public JavajaotanCommand.Cmd register(Command.Builder<JDACommandSender> builder) {
+        return new JavajaotanCommand.Cmd(
+            builder
+                .meta(CommandMeta.DESCRIPTION, "Google翻訳を用いてヘブライ語へ翻訳をしたあと、日本語へ翻訳を行います。")
+                .argument(StringArgument.greedy("text"))
+                .handler(context -> execute(context, this::translateHeJa))
+                .build()
+        );
+    }
+
+    private void translateHeJa(@NotNull Guild guild, @NotNull MessageChannel channel, @NotNull Member member, @NotNull Message message, @NotNull CommandContext<JDACommandSender> context) {
+        String text = context.get("text");
+
+        Translate.Language lang1 = Translate.Language.HE;
+        Translate.Language lang2 = Translate.Language.JA;
+
+        Translate.TranslateResult result1 = Translate.translate(
+            Translate.Language.UNKNOWN,
+            lang1,
+            text
+        );
+        if (result1 == null) {
+            message.reply("翻訳に失敗しました。").queue();
+            return;
+        }
+
+        Translate.TranslateResult result2 = Translate.translate(
+            lang1,
+            lang2,
+            text
+        );
+        if (result2 == null) {
+            message.reply("翻訳に失敗しました。").queue();
+            return;
+        }
+
+        EmbedBuilder embed = new EmbedBuilder()
+            .setTitle("翻訳が成功しました:clap:")
+            .addField("`%s` -> `%s`".formatted(result1.from().toString(), lang1.toString()),
+                "```%s```".formatted(text),
+                false)
+            .addField("`%s` -> `%s`".formatted(lang1.toString(), lang2.toString()),
+                "```%s```".formatted(text),
+                false)
+            .setColor(Color.PINK)
+            .setTimestamp(Instant.now());
+        message.replyEmbeds(embed.build()).queue();
+    }
+}

--- a/src/main/java/com/jaoafa/javajaotan2/command/Cmd_ToHeJa.java
+++ b/src/main/java/com/jaoafa/javajaotan2/command/Cmd_ToHeJa.java
@@ -78,11 +78,11 @@ public class Cmd_ToHeJa implements CommandPremise {
         EmbedBuilder embed = new EmbedBuilder()
             .setTitle("翻訳が成功しました:clap:")
             .addField("`%s` -> `%s`".formatted(result1.from().toString(), lang1.toString()),
-                "```%s```".formatted(text),
-                false)
+                "```%s```".formatted(result1.result()),
+                true)
             .addField("`%s` -> `%s`".formatted(lang1.toString(), lang2.toString()),
-                "```%s```".formatted(text),
-                false)
+                "```%s```".formatted(result2.result()),
+                true)
             .setColor(Color.PINK)
             .setTimestamp(Instant.now());
         message.replyEmbeds(embed.build()).queue();

--- a/src/main/java/com/jaoafa/javajaotan2/command/Cmd_ToJa.java
+++ b/src/main/java/com/jaoafa/javajaotan2/command/Cmd_ToJa.java
@@ -1,0 +1,67 @@
+/*
+ * jaoLicense
+ *
+ * Copyright (c) 2021 jao Minecraft Server
+ *
+ * The following license applies to this project: jaoLicense
+ *
+ * Japanese: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE.md
+ * English: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE-en.md
+ */
+
+package com.jaoafa.javajaotan2.command;
+
+import cloud.commandframework.Command;
+import cloud.commandframework.arguments.standard.StringArgument;
+import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.jda.JDACommandSender;
+import cloud.commandframework.meta.CommandMeta;
+import com.jaoafa.javajaotan2.lib.CommandPremise;
+import com.jaoafa.javajaotan2.lib.JavajaotanCommand;
+import com.jaoafa.javajaotan2.lib.Translate;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageChannel;
+import org.jetbrains.annotations.NotNull;
+
+public class Cmd_ToJa implements CommandPremise {
+    @Override
+    public JavajaotanCommand.Detail details() {
+        return new JavajaotanCommand.Detail(
+            "toja",
+            "Google翻訳を用いて日本語へ翻訳を行います。"
+        );
+    }
+
+    @Override
+    public JavajaotanCommand.Cmd register(Command.Builder<JDACommandSender> builder) {
+        return new JavajaotanCommand.Cmd(
+            builder
+                .meta(CommandMeta.DESCRIPTION, "Google翻訳を用いて日本語へ翻訳を行います。")
+                .argument(StringArgument.greedy("text"))
+                .handler(context -> execute(context, this::translateJa))
+                .build()
+        );
+    }
+
+    private void translateJa(@NotNull Guild guild, @NotNull MessageChannel channel, @NotNull Member member, @NotNull Message message, @NotNull CommandContext<JDACommandSender> context) {
+        String text = context.get("text");
+
+        Translate.TranslateResult result = Translate.translate(
+            Translate.Language.AUTO,
+            Translate.Language.JA,
+            text
+        );
+        if (result == null) {
+            message.reply("翻訳に失敗しました。").queue();
+            return;
+        }
+
+        message.reply("```%s```\n`%s` -> `%s`".formatted(
+            result.result(),
+            result.from().toString(),
+            result.to().toString()
+        )).queue();
+    }
+}

--- a/src/main/java/com/jaoafa/javajaotan2/command/Cmd_ToJa.java
+++ b/src/main/java/com/jaoafa/javajaotan2/command/Cmd_ToJa.java
@@ -49,7 +49,7 @@ public class Cmd_ToJa implements CommandPremise {
         String text = context.get("text");
 
         Translate.TranslateResult result = Translate.translate(
-            Translate.Language.AUTO,
+            Translate.Language.UNKNOWN,
             Translate.Language.JA,
             text
         );

--- a/src/main/java/com/jaoafa/javajaotan2/command/Cmd_ToRandJa.java
+++ b/src/main/java/com/jaoafa/javajaotan2/command/Cmd_ToRandJa.java
@@ -81,11 +81,11 @@ public class Cmd_ToRandJa implements CommandPremise {
         EmbedBuilder embed = new EmbedBuilder()
             .setTitle("翻訳が成功しました:clap:")
             .addField("`%s` -> `%s`".formatted(result1.from().toString(), lang1.toString()),
-                "```%s```".formatted(text),
-                false)
+                "```%s```".formatted(result1.result()),
+                true)
             .addField("`%s` -> `%s`".formatted(lang1.toString(), lang2.toString()),
-                "```%s```".formatted(text),
-                false)
+                "```%s```".formatted(result2.result()),
+                true)
             .setColor(Color.PINK)
             .setTimestamp(Instant.now());
         message.replyEmbeds(embed.build()).queue();

--- a/src/main/java/com/jaoafa/javajaotan2/command/Cmd_ToRandJa.java
+++ b/src/main/java/com/jaoafa/javajaotan2/command/Cmd_ToRandJa.java
@@ -1,0 +1,93 @@
+/*
+ * jaoLicense
+ *
+ * Copyright (c) 2021 jao Minecraft Server
+ *
+ * The following license applies to this project: jaoLicense
+ *
+ * Japanese: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE.md
+ * English: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE-en.md
+ */
+
+package com.jaoafa.javajaotan2.command;
+
+import cloud.commandframework.Command;
+import cloud.commandframework.arguments.standard.StringArgument;
+import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.jda.JDACommandSender;
+import cloud.commandframework.meta.CommandMeta;
+import com.jaoafa.javajaotan2.lib.CommandPremise;
+import com.jaoafa.javajaotan2.lib.JavajaotanCommand;
+import com.jaoafa.javajaotan2.lib.Translate;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageChannel;
+import org.jetbrains.annotations.NotNull;
+
+import java.awt.*;
+import java.time.Instant;
+import java.util.List;
+import java.util.Random;
+
+public class Cmd_ToRandJa implements CommandPremise {
+    @Override
+    public JavajaotanCommand.Detail details() {
+        return new JavajaotanCommand.Detail(
+            "torandja",
+            List.of("torandomja"),
+            "Google翻訳を用いてランダムな言語へ翻訳をしたあと、日本語へ翻訳を行います。"
+        );
+    }
+
+    @Override
+    public JavajaotanCommand.Cmd register(Command.Builder<JDACommandSender> builder) {
+        return new JavajaotanCommand.Cmd(
+            builder
+                .meta(CommandMeta.DESCRIPTION, "Google翻訳を用いてランダムな言語へ翻訳をしたあと、日本語へ翻訳を行います。")
+                .argument(StringArgument.greedy("text"))
+                .handler(context -> execute(context, this::translateRandJa))
+                .build()
+        );
+    }
+
+    private void translateRandJa(@NotNull Guild guild, @NotNull MessageChannel channel, @NotNull Member member, @NotNull Message message, @NotNull CommandContext<JDACommandSender> context) {
+        String text = context.get("text");
+
+        Translate.Language lang1 = Translate.Language.values()[new Random().nextInt(Translate.Language.values().length)];
+        Translate.Language lang2 = Translate.Language.JA;
+
+        Translate.TranslateResult result1 = Translate.translate(
+            Translate.Language.UNKNOWN,
+            lang1,
+            text
+        );
+        if (result1 == null) {
+            message.reply("翻訳に失敗しました。").queue();
+            return;
+        }
+
+        Translate.TranslateResult result2 = Translate.translate(
+            lang1,
+            lang2,
+            text
+        );
+        if (result2 == null) {
+            message.reply("翻訳に失敗しました。").queue();
+            return;
+        }
+
+        EmbedBuilder embed = new EmbedBuilder()
+            .setTitle("翻訳が成功しました:clap:")
+            .addField("`%s` -> `%s`".formatted(result1.from().toString(), lang1.toString()),
+                "```%s```".formatted(text),
+                false)
+            .addField("`%s` -> `%s`".formatted(lang1.toString(), lang2.toString()),
+                "```%s```".formatted(text),
+                false)
+            .setColor(Color.PINK)
+            .setTimestamp(Instant.now());
+        message.replyEmbeds(embed.build()).queue();
+    }
+}

--- a/src/main/java/com/jaoafa/javajaotan2/command/Cmd_ToSw.java
+++ b/src/main/java/com/jaoafa/javajaotan2/command/Cmd_ToSw.java
@@ -49,7 +49,7 @@ public class Cmd_ToSw implements CommandPremise {
         String text = context.get("text");
 
         Translate.TranslateResult result = Translate.translate(
-            Translate.Language.AUTO,
+            Translate.Language.UNKNOWN,
             Translate.Language.SW,
             text
         );

--- a/src/main/java/com/jaoafa/javajaotan2/command/Cmd_ToSw.java
+++ b/src/main/java/com/jaoafa/javajaotan2/command/Cmd_ToSw.java
@@ -1,0 +1,67 @@
+/*
+ * jaoLicense
+ *
+ * Copyright (c) 2021 jao Minecraft Server
+ *
+ * The following license applies to this project: jaoLicense
+ *
+ * Japanese: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE.md
+ * English: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE-en.md
+ */
+
+package com.jaoafa.javajaotan2.command;
+
+import cloud.commandframework.Command;
+import cloud.commandframework.arguments.standard.StringArgument;
+import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.jda.JDACommandSender;
+import cloud.commandframework.meta.CommandMeta;
+import com.jaoafa.javajaotan2.lib.CommandPremise;
+import com.jaoafa.javajaotan2.lib.JavajaotanCommand;
+import com.jaoafa.javajaotan2.lib.Translate;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageChannel;
+import org.jetbrains.annotations.NotNull;
+
+public class Cmd_ToSw implements CommandPremise {
+    @Override
+    public JavajaotanCommand.Detail details() {
+        return new JavajaotanCommand.Detail(
+            "tosw",
+            "Google翻訳を用いてスワヒリ語へ翻訳を行います。"
+        );
+    }
+
+    @Override
+    public JavajaotanCommand.Cmd register(Command.Builder<JDACommandSender> builder) {
+        return new JavajaotanCommand.Cmd(
+            builder
+                .meta(CommandMeta.DESCRIPTION, "Google翻訳を用いてスワヒリ語へ翻訳を行います。")
+                .argument(StringArgument.greedy("text"))
+                .handler(context -> execute(context, this::translateSw))
+                .build()
+        );
+    }
+
+    private void translateSw(@NotNull Guild guild, @NotNull MessageChannel channel, @NotNull Member member, @NotNull Message message, @NotNull CommandContext<JDACommandSender> context) {
+        String text = context.get("text");
+
+        Translate.TranslateResult result = Translate.translate(
+            Translate.Language.AUTO,
+            Translate.Language.SW,
+            text
+        );
+        if (result == null) {
+            message.reply("翻訳に失敗しました。").queue();
+            return;
+        }
+
+        message.reply("```%s```\n`%s` -> `%s`".formatted(
+            result.result(),
+            result.from().toString(),
+            result.to().toString()
+        )).queue();
+    }
+}

--- a/src/main/java/com/jaoafa/javajaotan2/command/Cmd_ToSwJa.java
+++ b/src/main/java/com/jaoafa/javajaotan2/command/Cmd_ToSwJa.java
@@ -1,0 +1,90 @@
+/*
+ * jaoLicense
+ *
+ * Copyright (c) 2021 jao Minecraft Server
+ *
+ * The following license applies to this project: jaoLicense
+ *
+ * Japanese: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE.md
+ * English: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE-en.md
+ */
+
+package com.jaoafa.javajaotan2.command;
+
+import cloud.commandframework.Command;
+import cloud.commandframework.arguments.standard.StringArgument;
+import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.jda.JDACommandSender;
+import cloud.commandframework.meta.CommandMeta;
+import com.jaoafa.javajaotan2.lib.CommandPremise;
+import com.jaoafa.javajaotan2.lib.JavajaotanCommand;
+import com.jaoafa.javajaotan2.lib.Translate;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageChannel;
+import org.jetbrains.annotations.NotNull;
+
+import java.awt.*;
+import java.time.Instant;
+
+public class Cmd_ToSwJa implements CommandPremise {
+    @Override
+    public JavajaotanCommand.Detail details() {
+        return new JavajaotanCommand.Detail(
+            "toswja",
+            "Google翻訳を用いてスワヒリ語へ翻訳をしたあと、日本語へ翻訳を行います。"
+        );
+    }
+
+    @Override
+    public JavajaotanCommand.Cmd register(Command.Builder<JDACommandSender> builder) {
+        return new JavajaotanCommand.Cmd(
+            builder
+                .meta(CommandMeta.DESCRIPTION, "Google翻訳を用いてスワヒリ語へ翻訳をしたあと、日本語へ翻訳を行います。")
+                .argument(StringArgument.greedy("text"))
+                .handler(context -> execute(context, this::translateSwJa))
+                .build()
+        );
+    }
+
+    private void translateSwJa(@NotNull Guild guild, @NotNull MessageChannel channel, @NotNull Member member, @NotNull Message message, @NotNull CommandContext<JDACommandSender> context) {
+        String text = context.get("text");
+
+        Translate.Language lang1 = Translate.Language.SW;
+        Translate.Language lang2 = Translate.Language.JA;
+
+        Translate.TranslateResult result1 = Translate.translate(
+            Translate.Language.UNKNOWN,
+            lang1,
+            text
+        );
+        if (result1 == null) {
+            message.reply("翻訳に失敗しました。").queue();
+            return;
+        }
+
+        Translate.TranslateResult result2 = Translate.translate(
+            lang1,
+            lang2,
+            text
+        );
+        if (result2 == null) {
+            message.reply("翻訳に失敗しました。").queue();
+            return;
+        }
+
+        EmbedBuilder embed = new EmbedBuilder()
+            .setTitle("翻訳が成功しました:clap:")
+            .addField("`%s` -> `%s`".formatted(result1.from().toString(), lang1.toString()),
+                "```%s```".formatted(text),
+                false)
+            .addField("`%s` -> `%s`".formatted(lang1.toString(), lang2.toString()),
+                "```%s```".formatted(text),
+                false)
+            .setColor(Color.PINK)
+            .setTimestamp(Instant.now());
+        message.replyEmbeds(embed.build()).queue();
+    }
+}

--- a/src/main/java/com/jaoafa/javajaotan2/command/Cmd_ToSwJa.java
+++ b/src/main/java/com/jaoafa/javajaotan2/command/Cmd_ToSwJa.java
@@ -78,11 +78,11 @@ public class Cmd_ToSwJa implements CommandPremise {
         EmbedBuilder embed = new EmbedBuilder()
             .setTitle("翻訳が成功しました:clap:")
             .addField("`%s` -> `%s`".formatted(result1.from().toString(), lang1.toString()),
-                "```%s```".formatted(text),
-                false)
+                "```%s```".formatted(result1.result()),
+                true)
             .addField("`%s` -> `%s`".formatted(lang1.toString(), lang2.toString()),
-                "```%s```".formatted(text),
-                false)
+                "```%s```".formatted(result2.result()),
+                true)
             .setColor(Color.PINK)
             .setTimestamp(Instant.now());
         message.replyEmbeds(embed.build()).queue();

--- a/src/main/java/com/jaoafa/javajaotan2/command/Cmd_ToZh.java
+++ b/src/main/java/com/jaoafa/javajaotan2/command/Cmd_ToZh.java
@@ -1,0 +1,67 @@
+/*
+ * jaoLicense
+ *
+ * Copyright (c) 2021 jao Minecraft Server
+ *
+ * The following license applies to this project: jaoLicense
+ *
+ * Japanese: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE.md
+ * English: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE-en.md
+ */
+
+package com.jaoafa.javajaotan2.command;
+
+import cloud.commandframework.Command;
+import cloud.commandframework.arguments.standard.StringArgument;
+import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.jda.JDACommandSender;
+import cloud.commandframework.meta.CommandMeta;
+import com.jaoafa.javajaotan2.lib.CommandPremise;
+import com.jaoafa.javajaotan2.lib.JavajaotanCommand;
+import com.jaoafa.javajaotan2.lib.Translate;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageChannel;
+import org.jetbrains.annotations.NotNull;
+
+public class Cmd_ToZh implements CommandPremise {
+    @Override
+    public JavajaotanCommand.Detail details() {
+        return new JavajaotanCommand.Detail(
+            "tosw",
+            "Google翻訳を用いて中国語へ翻訳を行います。"
+        );
+    }
+
+    @Override
+    public JavajaotanCommand.Cmd register(Command.Builder<JDACommandSender> builder) {
+        return new JavajaotanCommand.Cmd(
+            builder
+                .meta(CommandMeta.DESCRIPTION, "Google翻訳を用いて中国語へ翻訳を行います。")
+                .argument(StringArgument.greedy("text"))
+                .handler(context -> execute(context, this::translateZh))
+                .build()
+        );
+    }
+
+    private void translateZh(@NotNull Guild guild, @NotNull MessageChannel channel, @NotNull Member member, @NotNull Message message, @NotNull CommandContext<JDACommandSender> context) {
+        String text = context.get("text");
+
+        Translate.TranslateResult result = Translate.translate(
+            Translate.Language.AUTO,
+            Translate.Language.ZH,
+            text
+        );
+        if (result == null) {
+            message.reply("翻訳に失敗しました。").queue();
+            return;
+        }
+
+        message.reply("```%s```\n`%s` -> `%s`".formatted(
+            result.result(),
+            result.from().toString(),
+            result.to().toString()
+        )).queue();
+    }
+}

--- a/src/main/java/com/jaoafa/javajaotan2/command/Cmd_ToZh.java
+++ b/src/main/java/com/jaoafa/javajaotan2/command/Cmd_ToZh.java
@@ -49,7 +49,7 @@ public class Cmd_ToZh implements CommandPremise {
         String text = context.get("text");
 
         Translate.TranslateResult result = Translate.translate(
-            Translate.Language.AUTO,
+            Translate.Language.UNKNOWN,
             Translate.Language.ZH,
             text
         );

--- a/src/main/java/com/jaoafa/javajaotan2/command/Cmd_ToZhJa.java
+++ b/src/main/java/com/jaoafa/javajaotan2/command/Cmd_ToZhJa.java
@@ -1,0 +1,90 @@
+/*
+ * jaoLicense
+ *
+ * Copyright (c) 2021 jao Minecraft Server
+ *
+ * The following license applies to this project: jaoLicense
+ *
+ * Japanese: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE.md
+ * English: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE-en.md
+ */
+
+package com.jaoafa.javajaotan2.command;
+
+import cloud.commandframework.Command;
+import cloud.commandframework.arguments.standard.StringArgument;
+import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.jda.JDACommandSender;
+import cloud.commandframework.meta.CommandMeta;
+import com.jaoafa.javajaotan2.lib.CommandPremise;
+import com.jaoafa.javajaotan2.lib.JavajaotanCommand;
+import com.jaoafa.javajaotan2.lib.Translate;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageChannel;
+import org.jetbrains.annotations.NotNull;
+
+import java.awt.*;
+import java.time.Instant;
+
+public class Cmd_ToZhJa implements CommandPremise {
+    @Override
+    public JavajaotanCommand.Detail details() {
+        return new JavajaotanCommand.Detail(
+            "toswja",
+            "Google翻訳を用いて中国語へ翻訳をしたあと、日本語へ翻訳を行います。"
+        );
+    }
+
+    @Override
+    public JavajaotanCommand.Cmd register(Command.Builder<JDACommandSender> builder) {
+        return new JavajaotanCommand.Cmd(
+            builder
+                .meta(CommandMeta.DESCRIPTION, "Google翻訳を用いて中国語へ翻訳をしたあと、日本語へ翻訳を行います。")
+                .argument(StringArgument.greedy("text"))
+                .handler(context -> execute(context, this::translateZhJa))
+                .build()
+        );
+    }
+
+    private void translateZhJa(@NotNull Guild guild, @NotNull MessageChannel channel, @NotNull Member member, @NotNull Message message, @NotNull CommandContext<JDACommandSender> context) {
+        String text = context.get("text");
+
+        Translate.Language lang1 = Translate.Language.ZH;
+        Translate.Language lang2 = Translate.Language.JA;
+
+        Translate.TranslateResult result1 = Translate.translate(
+            Translate.Language.UNKNOWN,
+            lang1,
+            text
+        );
+        if (result1 == null) {
+            message.reply("翻訳に失敗しました。").queue();
+            return;
+        }
+
+        Translate.TranslateResult result2 = Translate.translate(
+            lang1,
+            lang2,
+            text
+        );
+        if (result2 == null) {
+            message.reply("翻訳に失敗しました。").queue();
+            return;
+        }
+
+        EmbedBuilder embed = new EmbedBuilder()
+            .setTitle("翻訳が成功しました:clap:")
+            .addField("`%s` -> `%s`".formatted(result1.from().toString(), lang1.toString()),
+                "```%s```".formatted(text),
+                false)
+            .addField("`%s` -> `%s`".formatted(lang1.toString(), lang2.toString()),
+                "```%s```".formatted(text),
+                false)
+            .setColor(Color.PINK)
+            .setTimestamp(Instant.now());
+        message.replyEmbeds(embed.build()).queue();
+    }
+}

--- a/src/main/java/com/jaoafa/javajaotan2/command/Cmd_ToZhJa.java
+++ b/src/main/java/com/jaoafa/javajaotan2/command/Cmd_ToZhJa.java
@@ -78,11 +78,11 @@ public class Cmd_ToZhJa implements CommandPremise {
         EmbedBuilder embed = new EmbedBuilder()
             .setTitle("翻訳が成功しました:clap:")
             .addField("`%s` -> `%s`".formatted(result1.from().toString(), lang1.toString()),
-                "```%s```".formatted(text),
-                false)
+                "```%s```".formatted(result1.result()),
+                true)
             .addField("`%s` -> `%s`".formatted(lang1.toString(), lang2.toString()),
-                "```%s```".formatted(text),
-                false)
+                "```%s```".formatted(result2.result()),
+                true)
             .setColor(Color.PINK)
             .setTimestamp(Instant.now());
         message.replyEmbeds(embed.build()).queue();

--- a/src/main/java/com/jaoafa/javajaotan2/command/Cmd_Translate.java
+++ b/src/main/java/com/jaoafa/javajaotan2/command/Cmd_Translate.java
@@ -1,0 +1,78 @@
+/*
+ * jaoLicense
+ *
+ * Copyright (c) 2021 jao Minecraft Server
+ *
+ * The following license applies to this project: jaoLicense
+ *
+ * Japanese: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE.md
+ * English: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE-en.md
+ */
+
+package com.jaoafa.javajaotan2.command;
+
+import cloud.commandframework.Command;
+import cloud.commandframework.arguments.standard.StringArgument;
+import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.jda.JDACommandSender;
+import cloud.commandframework.meta.CommandMeta;
+import com.jaoafa.javajaotan2.lib.CommandPremise;
+import com.jaoafa.javajaotan2.lib.JavajaotanCommand;
+import com.jaoafa.javajaotan2.lib.Translate;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageChannel;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public class Cmd_Translate implements CommandPremise {
+    @Override
+    public JavajaotanCommand.Detail details() {
+        return new JavajaotanCommand.Detail(
+            "translate",
+            List.of("to"),
+            "Google翻訳を用いて翻訳を行います。"
+        );
+    }
+
+    @Override
+    public JavajaotanCommand.Cmd register(Command.Builder<JDACommandSender> builder) {
+        return new JavajaotanCommand.Cmd(
+            builder
+                .meta(CommandMeta.DESCRIPTION, "Google翻訳を用いて翻訳を行います。")
+                .argument(StringArgument.of("from"))
+                .argument(StringArgument.of("to"))
+                .argument(StringArgument.greedy("text"))
+                .handler(context -> execute(context, this::translate))
+                .build()
+        );
+    }
+
+    private void translate(@NotNull Guild guild, @NotNull MessageChannel channel, @NotNull Member member, @NotNull Message message, @NotNull CommandContext<JDACommandSender> context) {
+        String from_raw = context.get("from");
+        String to_raw = context.get("to");
+        String text = context.get("text");
+
+        Translate.Language from = Translate.getLanguage(from_raw);
+        Translate.Language to = Translate.getLanguage(to_raw);
+
+        if (to == Translate.Language.UNKNOWN) {
+            message.reply("翻訳先の言語が不明です。").queue();
+            return;
+        }
+
+        Translate.TranslateResult result = Translate.translate(from, to, text);
+        if (result == null) {
+            message.reply("翻訳に失敗しました。").queue();
+            return;
+        }
+
+        message.reply("```%s```\n`%s` -> `%s`".formatted(
+            result.result(),
+            result.from().toString(),
+            result.to().toString()
+        )).queue();
+    }
+}

--- a/src/main/java/com/jaoafa/javajaotan2/lib/JavajaotanConfig.java
+++ b/src/main/java/com/jaoafa/javajaotan2/lib/JavajaotanConfig.java
@@ -12,6 +12,7 @@
 package com.jaoafa.javajaotan2.lib;
 
 import com.jaoafa.javajaotan2.Main;
+import org.jetbrains.annotations.Nullable;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.slf4j.Logger;
@@ -26,6 +27,8 @@ public class JavajaotanConfig {
     long guild_id;
     String gcp_key;
     String customSearchCX;
+    String gasTranslateAPIUrl;
+    String detectLanguageAPIToken;
 
     public JavajaotanConfig() throws RuntimeException {
         logger = Main.getLogger();
@@ -46,8 +49,10 @@ public class JavajaotanConfig {
             // - 設定項目の取得
             token = config.getString("token");
             guild_id = config.optLong("guild_id", 597378876556967936L);
-            gcp_key = config.optString("gcp_key", null);
-            customSearchCX = config.optString("customSearchCX", null);
+            gcp_key = config.optString("gcp_key");
+            customSearchCX = config.optString("customSearchCX");
+            gasTranslateAPIUrl = config.optString("gasTranslateAPIUrl");
+            detectLanguageAPIToken = config.optString("detectLanguageAPIToken");
 
             // -- データベース関連
             if (config.has("main_database")) {
@@ -110,11 +115,22 @@ public class JavajaotanConfig {
         return guild_id;
     }
 
+    @Nullable
     public String getGCPKey() {
         return gcp_key;
     }
 
+    @Nullable
     public String getCustomSearchCX() {
         return customSearchCX;
+    }
+
+    @Nullable
+    public String getGASTranslateAPIUrl() {
+        return gasTranslateAPIUrl;
+    }
+
+    public String getDetectLanguageAPIToken() {
+        return detectLanguageAPIToken;
     }
 }

--- a/src/main/java/com/jaoafa/javajaotan2/lib/Translate.java
+++ b/src/main/java/com/jaoafa/javajaotan2/lib/Translate.java
@@ -1,0 +1,225 @@
+/*
+ * jaoLicense
+ *
+ * Copyright (c) 2021 jao Minecraft Server
+ *
+ * The following license applies to this project: jaoLicense
+ *
+ * Japanese: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE.md
+ * English: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE-en.md
+ */
+
+package com.jaoafa.javajaotan2.lib;
+
+import com.detectlanguage.DetectLanguage;
+import com.detectlanguage.errors.APIError;
+import com.jaoafa.javajaotan2.Main;
+import okhttp3.*;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.util.Locale;
+
+public class Translate {
+    public static TranslateResult translate(Language before, Language after, String text) {
+        String url = Main.getConfig().getGASTranslateAPIUrl();
+        if (url == null) {
+            throw new UndefinedTranslateAPIUrl();
+        }
+        if (before == Language.UNKNOWN) {
+            // 言語検出
+            before = detectLanguage(text);
+            if (before == Language.UNKNOWN) before = Language.AUTO;
+        }
+        try {
+            OkHttpClient client = new OkHttpClient();
+            RequestBody requestBody = RequestBody.create(
+                new JSONObject()
+                    .put("text", text)
+                    .put("before", before.name().replace("_", "-").toLowerCase(Locale.ROOT))
+                    .put("after", after.name().replace("_", "-").toLowerCase(Locale.ROOT))
+                    .toString(),
+                MediaType.parse("application/json; charset=utf-8")
+            );
+            Request request = new Request.Builder().url(url).post(requestBody).build();
+            Response response = client.newCall(request).execute();
+            ResponseBody body = response.body();
+            if (body == null) {
+                return null;
+            }
+            JSONObject object = new JSONObject(body.string());
+            return new TranslateResult(
+                object.getJSONObject("response").getString("result"),
+                before,
+                after
+            );
+        } catch (IOException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    static Language detectLanguage(String text) {
+        DetectLanguage.apiKey = Main.getConfig().getDetectLanguageAPIToken();
+        DetectLanguage.ssl = true;
+        try {
+            String language = DetectLanguage.simpleDetect(text);
+            Main.getLogger().info("detectLanguage: " + language);
+            if (language.equals("zh-Hant")) {
+                language = "zh-TW";
+            }
+            return getLanguage(language);
+        } catch (APIError e) {
+            e.printStackTrace();
+            return Language.UNKNOWN;
+        }
+    }
+
+    static class UndefinedTranslateAPIUrl extends RuntimeException {
+        public UndefinedTranslateAPIUrl() {
+            super("Translate API URL is not defined.");
+        }
+    }
+
+    public static Language getLanguage(String language) {
+        try {
+            return Language.valueOf(language.replace("-", "_").toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            e.printStackTrace();
+            return Language.UNKNOWN;
+        }
+    }
+
+    public record TranslateResult(
+        String result,
+        Language from,
+        Language to
+    ) {
+    }
+
+    public enum Language {
+        AUTO("自動検出"),
+        AF("アフリカーンス語"),
+        SQ("アルバニア語"),
+        AM("アムハラ語"),
+        AR("アラビア文字"),
+        HY("アルメニア語"),
+        AZ("アゼルバイジャン語"),
+        EU("バスク語"),
+        BE("ベラルーシ語"),
+        BN("ベンガル文字"),
+        BS("ボスニア語"),
+        BG("ブルガリア語"),
+        CA("カタロニア語"),
+        CEB("セブ語"),
+        ZH("中国語（簡体）"),
+        ZH_CN("中国語（簡体）"),
+        ZH_TW("中国語（繁体）"),
+        CO("コルシカ語"),
+        HR("クロアチア語"),
+        CS("チェコ語"),
+        DA("デンマーク語"),
+        NL("オランダ語"),
+        EN("英語"),
+        EO("エスペラント語"),
+        ET("エストニア語"),
+        FI("フィンランド語"),
+        FR("フランス語"),
+        FY("フリジア語"),
+        GL("ガリシア語"),
+        KA("グルジア語"),
+        DE("ドイツ語"),
+        EL("ギリシャ語"),
+        GU("グジャラト語"),
+        HT("クレオール語（ハイチ）"),
+        HA("ハウサ語"),
+        HAW("ハワイ語"),
+        HE("ヘブライ語"),
+        IW("ヘブライ語"),
+        HI("ヒンディー語"),
+        HMN("モン語"),
+        HU("ハンガリー語"),
+        IS("アイスランド語"),
+        IG("イボ語"),
+        ID("インドネシア語"),
+        GA("アイルランド語"),
+        IT("イタリア語"),
+        JA("日本語"),
+        JV("ジャワ語"),
+        KN("カンナダ語"),
+        KK("カザフ語"),
+        KM("クメール語"),
+        RW("キニヤルワンダ語"),
+        KO("韓国語"),
+        KU("クルド語"),
+        KY("キルギス語"),
+        LO("ラオ語"),
+        LV("ラトビア語"),
+        LT("リトアニア語"),
+        LB("ルクセンブルク語"),
+        MK("マケドニア語"),
+        MG("マラガシ語"),
+        MS("マレー語"),
+        ML("マラヤーラム文字"),
+        MT("マルタ語"),
+        MI("マオリ語"),
+        MR("マラーティー語"),
+        MN("モンゴル語"),
+        MY("ミャンマー語（ビルマ語）"),
+        NE("ネパール語"),
+        NO("ノルウェー語"),
+        NY("ニャンジャ語（チェワ語）"),
+        OR("オリヤ語"),
+        PS("パシュト語"),
+        FA("ペルシャ語"),
+        PL("ポーランド語"),
+        PT("ポルトガル語（ポルトガル、ブラジル）"),
+        PA("パンジャブ語"),
+        RO("ルーマニア語"),
+        RU("ロシア語"),
+        SM("サモア語"),
+        GD("スコットランド ゲール語"),
+        SR("セルビア語"),
+        ST("セソト語"),
+        SN("ショナ語"),
+        SD("シンド語"),
+        SI("シンハラ語"),
+        SK("スロバキア語"),
+        SL("スロベニア語"),
+        SO("ソマリ語"),
+        ES("スペイン語"),
+        SU("スンダ語"),
+        SW("スワヒリ語"),
+        SV("スウェーデン語"),
+        TL("タガログ語（フィリピン語）"),
+        TG("タジク語"),
+        TA("タミル語"),
+        TT("タタール語"),
+        TE("テルグ語"),
+        TH("タイ語"),
+        TR("トルコ語"),
+        TK("トルクメン語"),
+        UK("ウクライナ語"),
+        UR("ウルドゥー語"),
+        UG("ウイグル語"),
+        UZ("ウズベク語"),
+        VI("ベトナム語"),
+        CY("ウェールズ語"),
+        XH("コーサ語"),
+        YI("イディッシュ語"),
+        YO("ヨルバ語"),
+        ZU("ズールー語"),
+        UNKNOWN(null);
+
+        String language_name;
+
+        Language(String language_name) {
+            this.language_name = language_name;
+        }
+
+        @Override
+        public String toString() {
+            return language_name + "(" + name().replace("_", "-").toLowerCase(Locale.ROOT) + ")";
+        }
+    }
+}

--- a/src/test/com/jaoafa/javajaotan2/lib/TranslateTest.java
+++ b/src/test/com/jaoafa/javajaotan2/lib/TranslateTest.java
@@ -1,0 +1,48 @@
+package com.jaoafa.javajaotan2.lib;
+
+import com.jaoafa.javajaotan2.Main;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class TranslateTest {
+
+    @Test
+    void translateSimple() {
+        try {
+            Main.setConfig(new JavajaotanConfig());
+        } catch (RuntimeException e) {
+            e.printStackTrace();
+            return;
+        }
+        Translate.TranslateResult result = Translate.translate(
+            Translate.Language.EN,
+            Translate.Language.JA,
+            "Hello World."
+        );
+        assertNotNull(result);
+        assertEquals("こんにちは世界。", result.result());
+        assertEquals(Translate.Language.EN, result.from());
+        assertEquals(Translate.Language.JA, result.to());
+    }
+
+    @Test
+    void translateDetect() {
+        try {
+            Main.setConfig(new JavajaotanConfig());
+        } catch (RuntimeException e) {
+            e.printStackTrace();
+            return;
+        }
+        Translate.TranslateResult result = Translate.translate(
+            Translate.Language.UNKNOWN,
+            Translate.Language.JA,
+            "Hello World."
+        );
+        assertNotNull(result);
+        assertEquals("こんにちは世界。", result.result());
+        assertEquals(Translate.Language.EN, result.from());
+        assertEquals(Translate.Language.JA, result.to());
+    }
+}


### PR DESCRIPTION
close #155

- `/translate en ja TEXT`
- `/toja TEXT`: auto -> ja
- `/toen TEXT`: auto -> en
- `/tosw TEXT`: auto -> sw (スワヒリ語)
- `/tozh TEXT`: auto -> zh (中国語)
- `/toar TEXT`: auto -> ar (アラビア文字)
- `/tohe TEXT`: auto -> he (ヘブライ語)
- `/toenja TEXT`: auto -> en -> ja
- `/toswja TEXT`: auto -> sw -> ja
- `/tozhja TEXT`: auto -> zh -> ja
- `/toarja TEXT`: auto -> ar -> ja
- `/toheja TEXT`: auto -> he -> ja
- `/torandja`: auto -> ランダム -> ja