### PR TITLE
feat: TokenAutoDelete

### DIFF
--- a/src/main/java/com/jaoafa/javajaotan2/event/Event_TokenAutoDelete.java
+++ b/src/main/java/com/jaoafa/javajaotan2/event/Event_TokenAutoDelete.java
@@ -1,0 +1,42 @@
+/*
+ * jaoLicense
+ *
+ * Copyright (c) 2021 jao Minecraft Server
+ *
+ * The following license applies to this project: jaoLicense
+ *
+ * Japanese: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE.md
+ * English: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE-en.md
+ */
+
+package com.jaoafa.javajaotan2.event;
+
+import com.jaoafa.javajaotan2.Main;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import org.slf4j.Logger;
+
+import javax.annotation.Nonnull;
+import java.util.regex.Pattern;
+
+/**
+ * Discord Token のパターンにマッチするメッセージを消去
+ */
+public class Event_TokenAutoDelete extends ListenerAdapter {
+    @Override
+    public void onGuildMessageReceived(@Nonnull GuildMessageReceivedEvent event) {
+        Message message = event.getMessage();
+        String content = message.getContentRaw();
+
+        if (Pattern.compile("[a-zA-Z0-9]{23}\\.[a-zA-Z0-9]{6}\\.[a-zA-Z0-9]{27}").matcher(content).find())
+            message.delete().queue(msg -> {
+                User user = event.getAuthor();
+                Logger logger = Main.getLogger();
+
+                logger.warn("%s (%s) がTokenのパターンにマッチするメッセージを投稿しました！".formatted(user.getAsTag(), user.getId()));
+                logger.warn("内容 : " + content);
+            });
+    }
+}


### PR DESCRIPTION
## 実装・修正した内容の簡単な解説

Discord Token のパターンにマッチするメッセージを自動で削除する機能

## 関連する Issue

close #143 

## チェックリスト

> `[ ]` を `[x]` にすることでチェックできます

- [x] 【必須】[CONTRIBUTING](https://github.com/jaoafa/Javajaotan2/blob/master/CONTRIBUTING.md) を読みました
- [x] 【必須】テストサーバで動作確認をしました
  - [x] ローカルサーバで動作確認しました
  - [ ] ZakuroHatのテストサーバで動作確認しました
- [x] 【必須】プロジェクトのコードスタイルに適合しています（IDEAのコミット前処理でフォーマットして下さい）
- [x] 【必須】`NULL` が返却されるかもしれない(`@Nullable`)メソッドや変数は NULL チェックを実装しました
- [x] 非推奨とされているメソッド・クラスなどを使用していません（なるべく推奨されるメソッドなどに置き換える）
  - [ ] 代替メソッド・クラスなどがないため、非推奨メソッドなどを使用しています
- [ ] 複数のクラスにわたって使用される変数があるので、 `JavajaotanData` にその変数を作成し管理しています
- [ ] 複数のクラスにわたって多く使用される関数があるので、 `JavajaotanLibrary` にその関数を作成し管理しています

## 追加情報

> 何か追加情報がある場合は記載してください


