### PR TITLE
feat: docs APIの実装し直し

### DIFF
--- a/src/main/java/com/jaoafa/javajaotan2/Main.java
+++ b/src/main/java/com/jaoafa/javajaotan2/Main.java
@@ -189,6 +189,13 @@ public class Main {
         }
         builder.addCommands(commands.toArray(new Command[0]));
 
+        // localhost:31002 でホストされるコマンド一覧APIへのコマンド登録
+        // Javajaotan無印で実装済みコマンドを取得する関係上、暫定的にコマンド名のみを返す
+        Main.commands = new JSONArray();
+        for (Command command : commands) {
+            Main.commands.put(new JSONObject().put("name", command.getName()));
+        }
+
         builder.setHelpWord("jaotanhelp");
         /*
         `this.arguments` の値は以下の3種類


### PR DESCRIPTION
`localhost:31002` で内部通信用 API サーバが稼働しています。
これの `/docs` エンドポイントの修正になります。

- close #328 