### PR TITLE
feat: WatchStickers

### DIFF
--- a/src/main/java/com/jaoafa/javajaotan2/Main.java
+++ b/src/main/java/com/jaoafa/javajaotan2/Main.java
@@ -60,6 +60,7 @@ public class Main {
     static JDA jda;
     static JSONArray commands;
     static WatchEmojis watchEmojis;
+    static WatchStickers watchStickers;
     static ScheduledExecutorService scheduler;
 
     public static void main(String[] args) {
@@ -133,6 +134,8 @@ public class Main {
         registerTask();
 
         watchEmojis = new WatchEmojis();
+
+        watchStickers = new WatchStickers();
 
         scheduler = Executors.newSingleThreadScheduledExecutor();
 
@@ -494,6 +497,10 @@ public class Main {
 
     public static WatchEmojis getWatchEmojis() {
         return watchEmojis;
+    }
+
+    public static WatchStickers getWatchStickers() {
+        return watchStickers;
     }
 
     public static ScheduledExecutorService getScheduler() {

--- a/src/main/java/com/jaoafa/javajaotan2/command/Cmd_WatchSticker.java
+++ b/src/main/java/com/jaoafa/javajaotan2/command/Cmd_WatchSticker.java
@@ -1,0 +1,118 @@
+/*
+ * jaoLicense
+ *
+ * Copyright (c) 2022 jao Minecraft Server
+ *
+ * The following license applies to this project: jaoLicense
+ *
+ * Japanese: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE.md
+ * English: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE-en.md
+ */
+
+package com.jaoafa.javajaotan2.command;
+
+import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jaoafa.javajaotan2.Main;
+import com.jaoafa.javajaotan2.lib.CommandAction;
+import com.jaoafa.javajaotan2.lib.CommandArgument;
+import com.jaoafa.javajaotan2.lib.CommandWithActions;
+import com.jaoafa.javajaotan2.lib.WatchStickers;
+import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel;
+import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
+
+import java.util.List;
+
+public class Cmd_WatchSticker extends CommandWithActions {
+    public Cmd_WatchSticker() {
+        this.name = "watchsticker";
+        this.help = "スタンプを監視する設定をします。";
+        this.actions = List.of(
+            new CommandAction("add", this::addWatch, List.of("log-channel"), "サーバをスタンプ監視対象に追加します。"),
+            new CommandAction("remove", this::removeWatch, "サーバをスタンプ監視対象から削除します。"),
+            new CommandAction("del", this::removeWatch, "サーバをスタンプ監視対象から削除します。"),
+            new CommandAction("delete", this::removeWatch, "サーバをスタンプ監視対象から削除します。")
+        );
+        this.arguments = CommandAction.getArguments(this.actions);
+    }
+
+    @Override
+    protected void execute(CommandEvent event) {
+        CommandAction.execute(this, event);
+    }
+
+    private void addWatch(CommandEvent event, List<String> argNames) {
+        Guild guild = event.getGuild();
+        Member member = event.getMember();
+        Message message = event.getMessage();
+        CommandArgument args = new CommandArgument(event.getArgs(), argNames, CommandAction.getStartArgumentIndex(this, event));
+        if (!member.hasPermission(Permission.ADMINISTRATOR)) {
+            message.reply("このコマンドを実行するには、サーバの管理者権限を持っている必要があります。").queue();
+            return;
+        }
+        Member selfMember = guild.getMember(Main.getJDA().getSelfUser());
+        if (selfMember == null) {
+            message.reply("Botユーザーのサーバメンバー情報を取得できませんでした。").queue();
+            return;
+        }
+        if (!selfMember.hasPermission(Permission.VIEW_AUDIT_LOGS)) {
+            message.reply("このコマンドを実行するには、jaotanがサーバの監査ログ閲覧権限を持っている必要があります。").queue();
+            return;
+        }
+        MessageChannel log_channel = parseChannelInput(guild, args.getString("log-channel"));
+
+        GuildChannel log_guild_channel = guild.getGuildChannelById(log_channel.getIdLong());
+        if (log_guild_channel == null) {
+            message.reply("ログチャンネルの情報を取得できませんでした。このサーバにあるチャンネルを指定していますか？").queue();
+            return;
+        }
+
+        if (!selfMember.hasPermission(log_guild_channel, Permission.MESSAGE_SEND)) {
+            message.reply("このコマンドを実行するには、jaotanがログチャンネルへの書き込み権限を持っている必要があります。").queue();
+            return;
+        }
+
+        WatchStickers watchStickers = Main.getWatchStickers();
+        watchStickers.addGuild(guild, log_channel);
+
+        message.reply(String.format("このサーバ「%s」をスタンプ監視対象に追加しました。\nログチャンネル: <#%s>",
+            guild.getName(),
+            log_channel.getId())).queue();
+    }
+
+    private void removeWatch(CommandEvent event) {
+        Guild guild = event.getGuild();
+        Member member = event.getMember();
+        Message message = event.getMessage();
+        if (!member.hasPermission(Permission.ADMINISTRATOR)) {
+            message.reply("このコマンドを実行するには、サーバの管理者権限を持っている必要があります。").queue();
+        }
+        WatchStickers watchStickers = Main.getWatchStickers();
+        if (watchStickers.getStickerGuild(guild).isEmpty()) {
+            message.reply("このサーバはスタンプ監視対象ではありません。").queue();
+            return;
+        }
+        watchStickers.removeGuild(guild);
+
+        message.reply(String.format("このサーバ「%s」をスタンプ監視対象から削除しました。", guild.getName())).queue();
+    }
+
+    private MessageChannel parseChannelInput(Guild guild, String str) {
+        // ID
+        if (str.matches("\\d+")) {
+            return guild.getTextChannelById(Long.parseLong(str));
+        }
+        // <#ID>
+        if (str.matches("<#\\d+>")) {
+            return guild.getTextChannelById(Long.parseLong(str.substring(2, str.length() - 1)));
+        }
+        // チャンネル名
+        return guild.getTextChannels().stream()
+            .filter(channel -> channel.getName().equals(str))
+            .findFirst()
+            .orElse(null);
+    }
+}

--- a/src/main/java/com/jaoafa/javajaotan2/event/Event_WatchStickers.java
+++ b/src/main/java/com/jaoafa/javajaotan2/event/Event_WatchStickers.java
@@ -1,0 +1,219 @@
+/*
+ * jaoLicense
+ *
+ * Copyright (c) 2022 jao Minecraft Server
+ *
+ * The following license applies to this project: jaoLicense
+ *
+ * Japanese: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE.md
+ * English: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE-en.md
+ */
+
+package com.jaoafa.javajaotan2.event;
+
+import com.jaoafa.javajaotan2.Main;
+import com.jaoafa.javajaotan2.lib.WatchStickers;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.audit.ActionType;
+import net.dv8tion.jda.api.audit.AuditLogEntry;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
+import net.dv8tion.jda.api.entities.sticker.GuildSticker;
+import net.dv8tion.jda.api.entities.sticker.StickerSnowflake;
+import net.dv8tion.jda.api.events.sticker.GuildStickerAddedEvent;
+import net.dv8tion.jda.api.events.sticker.GuildStickerRemovedEvent;
+import net.dv8tion.jda.api.events.sticker.update.GuildStickerUpdateAvailableEvent;
+import net.dv8tion.jda.api.events.sticker.update.GuildStickerUpdateDescriptionEvent;
+import net.dv8tion.jda.api.events.sticker.update.GuildStickerUpdateNameEvent;
+import net.dv8tion.jda.api.events.sticker.update.GuildStickerUpdateTagsEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import org.jetbrains.annotations.NotNull;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+public class Event_WatchStickers extends ListenerAdapter {
+    @Override
+    public void onGuildStickerAdded(@NotNull GuildStickerAddedEvent event) {
+        JDA jda = event.getJDA();
+        Guild guild = event.getGuild();
+        GuildSticker sticker = event.getGuild().retrieveSticker(StickerSnowflake.fromId(event.getSticker().getIdLong())).complete();
+        User user = sticker.getOwner();
+        if (user == null) {
+            user = sticker.retrieveOwner().complete();
+        }
+        if (user == null) {
+            Main.getLogger().warn("StickerOwner is null: " + sticker.getId());
+            return;
+        }
+
+        Optional<WatchStickers.StickerGuild> optGuild = Main.getWatchStickers().getStickerGuild(guild);
+        if (optGuild.isEmpty()) {
+            return;
+        }
+
+        WatchStickers.StickerGuild stickerGuild = optGuild.get();
+        long log_channel_id = stickerGuild.getLogChannelId();
+        TextChannel log_channel = jda.getTextChannelById(log_channel_id);
+        if (log_channel == null) {
+            return;
+        }
+        MessageEmbed embed = new EmbedBuilder()
+            .setAuthor(user.getAsTag(), "https://discord.com/users/" + user.getId(), user.getAvatarUrl())
+            .setTitle(String.format(":new:NEW STICKER : `%s` - :%s:", sticker.getName(), String.join(": :", sticker.getTags())))
+            .setThumbnail(sticker.getIconUrl())
+            .setTimestamp(Instant.now())
+            .build();
+        log_channel.sendMessageEmbeds(embed).queue();
+    }
+
+    @Override
+    public void onGuildStickerUpdateName(@NotNull GuildStickerUpdateNameEvent event) {
+        onStickerUpdate(
+            event.getJDA(),
+            event.getGuild(),
+            event.getSticker(),
+            new StickerUpdateRecord(
+                StickerUpdateType.NAME,
+                event.getOldValue(),
+                event.getNewValue()
+            )
+        );
+    }
+
+    @Override
+    public void onGuildStickerUpdateDescription(@NotNull GuildStickerUpdateDescriptionEvent event) {
+        onStickerUpdate(
+            event.getJDA(),
+            event.getGuild(),
+            event.getSticker(),
+            new StickerUpdateRecord(
+                StickerUpdateType.DESCRIPTION,
+                event.getOldValue(),
+                event.getNewValue()
+            )
+        );
+    }
+
+    @Override
+    public void onGuildStickerUpdateTags(@NotNull GuildStickerUpdateTagsEvent event) {
+        onStickerUpdate(
+            event.getJDA(),
+            event.getGuild(),
+            event.getSticker(),
+            new StickerUpdateRecord(
+                StickerUpdateType.TAGS,
+                String.join(", ", event.getOldValue()),
+                String.join(", ", event.getNewValue())
+            )
+        );
+    }
+
+    @Override
+    public void onGuildStickerUpdateAvailable(@NotNull GuildStickerUpdateAvailableEvent event) {
+        onStickerUpdate(
+            event.getJDA(),
+            event.getGuild(),
+            event.getSticker(),
+            new StickerUpdateRecord(
+                StickerUpdateType.AVAILABLE,
+                event.getOldValue().toString(),
+                event.getNewValue().toString()
+            )
+        );
+    }
+
+    void onStickerUpdate(JDA jda, Guild guild, GuildSticker sticker, StickerUpdateRecord record) {
+        Optional<WatchStickers.StickerGuild> optGuild = Main.getWatchStickers().getStickerGuild(guild);
+        if (optGuild.isEmpty()) {
+            return;
+        }
+
+        WatchStickers.StickerGuild emojiGuild = optGuild.get();
+        long log_channel_id = emojiGuild.getLogChannelId();
+        TextChannel log_channel = jda.getTextChannelById(log_channel_id);
+        if (log_channel == null) {
+            return;
+        }
+
+        List<AuditLogEntry> entries = guild.retrieveAuditLogs().type(ActionType.STICKER_UPDATE).limit(5).complete();
+        User user = null;
+        if (!entries.isEmpty()) {
+            for (AuditLogEntry entry : entries) {
+                if (entry.getTargetIdLong() != sticker.getIdLong()) {
+                    continue;
+                }
+                user = entry.getUser();
+            }
+        }
+
+        EmbedBuilder builder = new EmbedBuilder()
+            .setTitle(":repeat:UPDATED EMOJI(%s) : %s".formatted(record.type.name(), sticker.getName()))
+            .setThumbnail(sticker.getIconUrl())
+            .addField("Old", record.oldValue, true)
+            .addField("New", record.newValue, true)
+            .setTimestamp(Instant.now());
+
+        if (user != null) {
+            builder.setAuthor(user.getAsTag(), "https://discord.com/users/" + user.getId(), user.getAvatarUrl());
+        }
+        log_channel.sendMessageEmbeds(builder.build()).queue();
+    }
+
+    @Override
+    public void onGuildStickerRemoved(@NotNull GuildStickerRemovedEvent event) {
+        JDA jda = event.getJDA();
+        Guild guild = event.getGuild();
+        GuildSticker sticker = event.getSticker();
+
+        Optional<WatchStickers.StickerGuild> optGuild = Main.getWatchStickers().getStickerGuild(guild);
+        if (optGuild.isEmpty()) {
+            return;
+        }
+
+        WatchStickers.StickerGuild emojiGuild = optGuild.get();
+        long log_channel_id = emojiGuild.getLogChannelId();
+        TextChannel log_channel = jda.getTextChannelById(log_channel_id);
+        if (log_channel == null) {
+            return;
+        }
+
+        List<AuditLogEntry> entries = guild.retrieveAuditLogs().type(ActionType.STICKER_DELETE).limit(5).complete();
+        User user = null;
+        if (!entries.isEmpty()) {
+            for (AuditLogEntry entry : entries) {
+                if (entry.getTargetIdLong() != sticker.getIdLong()) {
+                    continue;
+                }
+                user = entry.getUser();
+            }
+        }
+
+        EmbedBuilder embed = new EmbedBuilder()
+            .setTitle(String.format(":wave:DELETED EMOJI : (`%s`)", sticker.getName()))
+            .setThumbnail(sticker.getIconUrl())
+            .setTimestamp(Instant.now());
+        if (user != null) {
+            embed.setAuthor(user.getAsTag(), "https://discord.com/users/" + user.getId(), user.getAvatarUrl());
+        }
+        log_channel.sendMessageEmbeds(embed.build()).queue();
+    }
+
+    record StickerUpdateRecord(
+        StickerUpdateType type,
+        String oldValue,
+        String newValue
+    ) {
+    }
+
+    enum StickerUpdateType {
+        NAME,
+        DESCRIPTION,
+        TAGS,
+        AVAILABLE,
+    }
+}

--- a/src/main/java/com/jaoafa/javajaotan2/lib/WatchStickers.java
+++ b/src/main/java/com/jaoafa/javajaotan2/lib/WatchStickers.java
@@ -1,0 +1,94 @@
+/*
+ * jaoLicense
+ *
+ * Copyright (c) 2022 jao Minecraft Server
+ *
+ * The following license applies to this project: jaoLicense
+ *
+ * Japanese: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE.md
+ * English: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE-en.md
+ */
+
+package com.jaoafa.javajaotan2.lib;
+
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
+import org.jetbrains.annotations.NotNull;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class WatchStickers {
+    final File file;
+    List<StickerGuild> guilds = new ArrayList<>();
+
+    public WatchStickers() {
+        file = new File("watch-stickers.json");
+        load();
+    }
+
+    public void addGuild(@NotNull Guild guild, @NotNull MessageChannel log_channel) {
+        guilds.add(new WatchStickers.StickerGuild(guild.getIdLong(), log_channel.getIdLong()));
+        save();
+    }
+
+    public void removeGuild(@NotNull Guild guild) {
+        guilds = guilds.stream().filter(g -> g.guild_id != guild.getIdLong()).collect(Collectors.toList());
+        save();
+    }
+
+    public Optional<WatchStickers.StickerGuild> getStickerGuild(@NotNull Guild guild) {
+        return guilds.stream().filter(g -> g.guild_id == guild.getIdLong()).findFirst();
+    }
+
+    public void load() {
+        if (!file.exists()) {
+            return;
+        }
+        try {
+            guilds.clear();
+            String json = Files.readString(file.toPath());
+            JSONArray array = new JSONArray(json);
+            for (int i = 0; i < array.length(); i++) {
+                JSONObject obj = array.getJSONObject(i);
+                guilds.add(new WatchStickers.StickerGuild(obj.getLong("guild_id"), obj.getLong("log_channel_id")));
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void save() {
+        JSONArray array = new JSONArray();
+        guilds.stream().map(WatchStickers.StickerGuild::asJSONObject).forEach(array::put);
+        try {
+            Files.writeString(file.toPath(), array.toString());
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public record StickerGuild(long guild_id, long log_channel_id) {
+
+        public long getGuildId() {
+            return guild_id;
+        }
+
+        public long getLogChannelId() {
+            return log_channel_id;
+        }
+
+        public JSONObject asJSONObject() {
+            return new JSONObject()
+                .put("guild_id", guild_id)
+                .put("log_channel_id", log_channel_id);
+        }
+    }
+}


### PR DESCRIPTION
- close #262 

サーバ(Guild)で作成・変更・削除されたスタンプ(Sticker)を事前登録されたログチャンネルに通知します。
サーバ絵文字とは異なり、インラインでスタンプを表現することはできない(単一メッセージに複数のスタンプを含められない)ので、スタンプ一覧チャンネルは設置せず、それに該当する機能もありません。

コマンドとして `/watchsticker` を追加しています。

参考: [DV8FromTheWorld/JDA#2315](https://togithub.com/DV8FromTheWorld/JDA/issues/2315)