### PR TITLE
fix: 鉱物系誘導文の緩和

### DIFF
--- a/src/main/java/com/jaoafa/javajaotan2/event/Event_VC_Minerals.java
+++ b/src/main/java/com/jaoafa/javajaotan2/event/Event_VC_Minerals.java
@@ -59,7 +59,7 @@ public class Event_VC_Minerals extends ListenerAdapter {
             }
             event
                 .getMessage()
-                .reply(":warning: <#774232617624797214> <#597790849249574933>")
+                .reply(":arrow_right: <#774232617624797214>")
                 .delay(1, TimeUnit.MINUTES, Main.getScheduler()) // delete 1 minute later
                 .flatMap(Message::delete)
                 .queue();


### PR DESCRIPTION
- close #397

`#vc` における鉱物系チャンネル誘導文の文章を叩いて柔らかくします

