### PR TITLE
fix: reaction when user sent only “afa”

### DIFF
--- a/src/main/java/com/jaoafa/javajaotan2/event/Event_Greeting.java
+++ b/src/main/java/com/jaoafa/javajaotan2/event/Event_Greeting.java
@@ -76,7 +76,7 @@ public class Event_Greeting extends ListenerAdapter {
             return;
         }
         if (!jaoPlayers.contains(member.getIdLong())) {
-            message.addReaction(Emoji.fromUnicode("\u274C")).queue(); // x
+            message.addReaction(Emoji.fromUnicode("\u27A1")).queue(); // ->
             return;
         }
         guild.addRoleToMember(member, role).queue();


### PR DESCRIPTION
## 実装・修正した内容の簡単な解説

#greeting に “afa” のみが投稿された場合のリアクションを ➡️ に変更しました。

## 関連する Issue

close https://github.com/jaoafa/jao-Minecraft-Server/issues/137



## チェックリスト

> `[ ]` を `[x]` にすることでチェックできます

- [x] 【必須】[CONTRIBUTING](https://github.com/jaoafa/Javajaotan2/blob/master/CONTRIBUTING.md) を読みました
- [ ] 【必須】テストサーバで動作確認をしました
  - [ ] ローカルサーバで動作確認しました
  - [ ] ZakuroHatのテストサーバで動作確認しました
- [ ] 【必須】プロジェクトのコードスタイルに適合しています（IDEAのコミット前処理でフォーマットして下さい）
- [ ] 【必須】`NULL` が返却されるかもしれない(`@Nullable`)メソッドや変数は NULL チェックを実装しました
- [ ] 非推奨とされているメソッド・クラスなどを使用していません（なるべく推奨されるメソッドなどに置き換える）
  - [ ] 代替メソッド・クラスなどがないため、非推奨メソッドなどを使用しています
- [ ] 複数のクラスにわたって使用される変数があるので、 `JavajaotanData` にその変数を作成し管理しています
- [ ] 複数のクラスにわたって多く使用される関数があるので、 `JavajaotanLibrary` にその関数を作成し管理しています

## 追加情報

> 何か追加情報がある場合は記載してください


